### PR TITLE
issuer and subject are now jsonb fields

### DIFF
--- a/certificate/certificate.go
+++ b/certificate/certificate.go
@@ -486,9 +486,15 @@ func (i Issuer) String() (str string) {
 		str += "C=" + strings.Join(i.Country, ", C=")
 	}
 	if len(i.Organisation) > 0 {
+		if str != "" {
+			str += ", "
+		}
 		str += "O=" + strings.Join(i.Organisation, ", O=")
 	}
 	if len(i.OrgUnit) > 0 {
+		if str != "" {
+			str += ", "
+		}
 		str += "OU=" + strings.Join(i.OrgUnit, ", OU=")
 	}
 	if str != "" {
@@ -505,9 +511,15 @@ func (s Subject) String() (str string) {
 		str += "C=" + strings.Join(s.Country, ", C=")
 	}
 	if len(s.Organisation) > 0 {
+		if str != "" {
+			str += ", "
+		}
 		str += "O=" + strings.Join(s.Organisation, ", O=")
 	}
 	if len(s.OrgUnit) > 0 {
+		if str != "" {
+			str += ", "
+		}
 		str += "OU=" + strings.Join(s.OrgUnit, ", OU=")
 	}
 	if str != "" {

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -4,8 +4,8 @@ CREATE TABLE certificates  (
 	sha256_fingerprint          varchar NOT NULL,
 	serial_number              	varchar NULL,
 	version                    	integer NULL,
-	subject                    	varchar NULL,
-	issuer                     	varchar NULL,
+	subject                    	jsonb NULL,
+	issuer                     	jsonb NULL,
 	is_ca                      	bool NULL,
 	not_valid_before           	timestamp NULL,
 	not_valid_after            	timestamp NULL,
@@ -88,4 +88,3 @@ GRANT SELECT ON analysis, certificates, scans, trust TO tlsobsscanner;
 GRANT INSERT ON analysis, certificates, scans, trust TO tlsobsscanner;
 GRANT UPDATE ON analysis, certificates, scans, trust TO tlsobsscanner;
 GRANT USAGE ON analysis_id_seq, certificates_id_seq, scans_id_seq, trust_id_seq TO tlsobsscanner;
-

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -29,7 +29,8 @@ CREATE TABLE certificates  (
 	in_android_root_store       bool NULL,
 	is_revoked                 	bool NULL,
 	revoked_at                 	timestamp NULL,
-	raw_cert					varchar NOT NULL
+	domains 										varchar NULL,
+	raw_cert										varchar NOT NULL
 );
 
 CREATE TABLE trust (

--- a/tools/fixsubjectNames.go
+++ b/tools/fixsubjectNames.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/mozilla/tls-observatory/certificate"
@@ -13,11 +14,11 @@ import (
 
 func main() {
 	db, err := database.RegisterConnection(
-		"postgres",
-		"postgres",
-		"pass",
-		"172.17.0.1:5432",
-		"disable")
+		os.Getenv("TLSOBS_POSTGRESDB"),
+		os.Getenv("TLSOBS_POSTGRESUSER"),
+		os.Getenv("TLSOBS_POSTGRESPASS"),
+		os.Getenv("TLSOBS_POSTGRES"),
+		"require")
 	defer db.Close()
 	if err != nil {
 		panic(err)

--- a/tools/fixsubjectNames.go
+++ b/tools/fixsubjectNames.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/mozilla/tls-observatory/certificate"
+	"github.com/mozilla/tls-observatory/database"
+)
+
+func main() {
+	db, err := database.RegisterConnection(
+		"postgres",
+		"postgres",
+		"pass",
+		"172.17.0.1:5432",
+		"disable")
+	defer db.Close()
+	if err != nil {
+		panic(err)
+	}
+	// batch side: do 100 certs at a time
+	limit := 100
+	batch := 0
+	for {
+		fmt.Println("Processing batch", batch*limit, "to", batch*limit+limit)
+		rows, err := db.Query(`SELECT id, raw_cert
+					FROM certificates
+					WHERE issuer IS NULL AND subject IS NULL AND domains IS NULL
+					LIMIT $1`, limit)
+		if rows != nil {
+			defer rows.Close()
+		}
+		if err != nil {
+			panic(fmt.Errorf("Error while retrieving certs: '%v'", err))
+		}
+		i := 0
+		for rows.Next() {
+			i++
+			var raw string
+			var id int64
+			err = rows.Scan(&id, &raw)
+			if err != nil {
+				fmt.Println("error while parsing cert", id, ":", err)
+				continue
+			}
+			certdata, err := base64.StdEncoding.DecodeString(raw)
+			if err != nil {
+				fmt.Println("error decoding base64 of cert", id, ":", err)
+				continue
+			}
+			c, err := x509.ParseCertificate(certdata)
+			if err != nil {
+				fmt.Println("error while x509 parsing cert", id, ":", err)
+				continue
+			}
+			issuer := certificate.Issuer{Country: c.Issuer.Country, CommonName: c.Issuer.CommonName, OrgUnit: c.Issuer.OrganizationalUnit, Organisation: c.Issuer.Organization}
+
+			issuerjs, err := json.Marshal(issuer)
+			if err != nil {
+				fmt.Println("error while marshalling issuer of cert", id, " : ", err)
+				continue
+			}
+
+			subject := certificate.Subject{Country: c.Subject.Country, CommonName: c.Subject.CommonName, OrgUnit: c.Subject.OrganizationalUnit, Organisation: c.Subject.Organization}
+			subjectjs, err := json.Marshal(subject)
+			if err != nil {
+				fmt.Println("error while marshalling subject of cert", id, " : ", err)
+				continue
+			}
+
+			domainstr := ""
+
+			if !c.IsCA {
+				domainfound := false
+				for _, d := range c.DNSNames {
+					if d == c.Subject.CommonName {
+						domainfound = true
+					}
+				}
+
+				var domains []string
+
+				if !domainfound {
+					domains = append(c.DNSNames, c.Subject.CommonName)
+				} else {
+					domains = c.DNSNames
+				}
+
+				domainstr = strings.Join(domains, ",")
+			}
+
+			_, err = db.Exec(`UPDATE certificates SET issuer=$1, subject=$2, domains=$3 WHERE id=$4`,
+				issuerjs, subjectjs, domainstr, id)
+			if err != nil {
+				fmt.Println("error while updating cert", id, "in database:", err)
+			}
+		}
+		if i == 0 {
+			fmt.Println("done!")
+			break
+		}
+		//offset += limit
+		batch++
+	}
+}


### PR DESCRIPTION
The proposed change breaks the current database schema as the issuer and subject fields are going from varchar to jsonb.

I think dropping and recreating these columns is the best thing we can do. 
Should I create a script to go through the whole certificates table, parse certificates and save the new form of the issuer and subject fields?

