### PR TITLE
Evaluation worker & scanners limits rework

### DIFF
--- a/conf/api.cfg
+++ b/conf/api.cfg
@@ -3,7 +3,7 @@
 # export TLSOBS_API_ENABLE=1
 Enable        = on
 
-GoRoutines    = 10
+MaxProc       = 10
 # IP:PORT of the postgres database, can be superseded by the environment variable
 # export TLSOBS_POSTGRES="127.0.0.1:5432"
 Postgres      = "127.0.0.1:5432"

--- a/conf/scanner.cfg
+++ b/conf/scanner.cfg
@@ -3,7 +3,9 @@
 # export TLSOBS_SCANNER_ENABLE=on
 Enable        = on
 
-GoRoutines    = 10 #number of times to multiply the number of machine cores
+# how many parallel processes are allowed to run. A good number is
+# to set this to 10*cores, because the scanner is mostly IO bound.
+MaxProc       = 40
 
 # IP:PORT of the postgres database, can be superseded by the environment variable
 # export TLSOBS_POSTGRES="127.0.0.1:5432"

--- a/config/config.go
+++ b/config/config.go
@@ -17,7 +17,7 @@ type Config struct {
 		PostgresPass   string
 		PostgresUseTLS bool
 		CipherscanPath string
-		GoRoutines     int // * cores = The Max number of spawned Goroutines
+		MaxProc        int
 	}
 	TrustStores struct {
 		UbuntuTS    string

--- a/database/database.go
+++ b/database/database.go
@@ -28,7 +28,8 @@ type Scan struct {
 	Complperc        int               `json:"completion_perc"`
 	Conn_info        connection.Stored `json:"connection_info"`
 	AnalysisResults  []Analysis        `json:"analysis,omitempty"`
-	Ack              bool
+	Ack              bool              `json:"ack"`
+	Attempts         int               `json:"attempts"` //number of retries
 }
 
 type Analysis struct {
@@ -57,7 +58,11 @@ func (db *DB) NewScan(domain string, rplay int) (Scan, error) {
 
 	var id int64
 
-	err := db.QueryRow("INSERT INTO scans (timestamp,target,replay,has_tls,is_valid,completion_perc,validation_error,conn_info,ack) VALUES($1,$2,$3,$4,$5,$6,$7,$8,$9) RETURNING id", timestamp, domain, rplay, false, false, 0, "", []byte("null"), false).Scan(&id)
+	err := db.QueryRow(`INSERT INTO scans
+			(timestamp, target, replay, has_tls, is_valid, completion_perc, validation_error, conn_info, ack, attempts)
+			VALUES($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+			RETURNING id`,
+		timestamp, domain, rplay, false, false, 0, "", []byte("null"), false, 1).Scan(&id)
 
 	if err != nil {
 		return Scan{}, err
@@ -78,10 +83,12 @@ func (db *DB) GetScanByID(id int64) (Scan, error) {
 	var ci []byte
 
 	row := db.QueryRow(`SELECT timestamp, target, replay, has_tls, cert_id, trust_id,
-	is_valid, completion_perc, validation_error, conn_info, ack FROM scans WHERE id=$1`, id)
+				   is_valid, completion_perc, validation_error, conn_info, ack, attempts
+			    FROM scans
+			    WHERE id=$1`, id)
 
 	err := row.Scan(&s.Timestamp, &s.Target, &s.Replay, &s.Has_tls, &cID, &tID,
-		&isvalid, &s.Complperc, &s.Validation_error, &ci, &s.Ack)
+		&isvalid, &s.Complperc, &s.Validation_error, &ci, &s.Ack, &s.Attempts)
 
 	if err != nil {
 		if err == sql.ErrNoRows {

--- a/database/database.go
+++ b/database/database.go
@@ -156,7 +156,7 @@ func (db *DB) UpdateScanCompletionPercentage(id int64, p int) error {
 }
 
 func (db *DB) InsertWorkerAnalysis(scanid int64, jsonRes []byte, workerName string) error {
-	_, err := db.Exec("INSERT INTO analysis(scan_id,worker_name,	output) VALUES($1,$2,$3)", scanid, workerName, jsonRes)
+	_, err := db.Exec("INSERT INTO analysis(scan_id,worker_name,output) VALUES($1,$2,$3)", scanid, workerName, jsonRes)
 
 	return err
 }

--- a/database/messaging.go
+++ b/database/messaging.go
@@ -81,14 +81,16 @@ func (db *DB) RegisterScanListener(dbname, user, password, hostport, sslmode str
 					"error": err,
 				}).Error("Could not run zero completion update query")
 			}
-
-			_, err = db.Exec(fmt.Sprintf("select pg_notify('%s', ''||id ) from scans where ack=FALSE and timestamp < NOW() - INTERVAL '30 seconds' LIMIT 1000", listenerName))
+			_, err = db.Exec(fmt.Sprintf(`SELECT pg_notify('%s', ''||id )
+						      FROM scans
+						      WHERE ack=FALSE
+						      ORDER BY id ASC
+						      LIMIT 100`, listenerName))
 			if err != nil {
 				log.WithFields(logrus.Fields{
 					"error": err,
 				}).Error("Could not run unacknowledged scans periodic check.")
 			}
-
 			time.Sleep(5 * time.Minute)
 		}
 	}()

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -29,8 +29,8 @@ CREATE TABLE certificates  (
 	in_android_root_store       bool NULL,
 	is_revoked                 	bool NULL,
 	revoked_at                 	timestamp NULL,
-	domains 										varchar NULL,
-	raw_cert										varchar NOT NULL
+	domains 					varchar NULL,
+	raw_cert					varchar NOT NULL
 );
 
 CREATE TABLE trust (

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -58,7 +58,8 @@ CREATE TABLE scans  (
 	completion_perc				integer NOT NULL,
 	validation_error           	varchar NOT NULL,
 	conn_info                	jsonb NOT NULL,
-	ack 						bool NOT NULL
+	ack 						bool NOT NULL,
+	attempts			        integer NULL
 );
 
 CREATE TABLE analysis  (

--- a/worker/mozillaEvaluationWorker/configurations.go
+++ b/worker/mozillaEvaluationWorker/configurations.go
@@ -17,13 +17,13 @@ var ServerSideTLSConfiguration = `{
                 "ECDHE-RSA-AES128-SHA256"
             ],
             "tls_versions": ["TLSv1.2" ],
-            "tls_curves": [ "secp384r1", "secp521r1" ],
+            "tls_curves": [ "prime256v1", "secp384r1", "secp521r1" ],
             "certificate_type": "ecdsa",
-            "certificate_curve": "secp384r1",
-            "certificate_signature": "ecdsa-with-SHA384",
+            "certificate_curve": "prime256v1",
+            "certificate_signature": "ecdsa-with-SHA256",
             "rsa_key_size": 2048,
             "dh_param_size": null,
-            "ecdh_param_size": 384,
+            "ecdh_param_size": 256,
             "hsts": "max-age=15768000",
             "oldest_clients": [ "Firefox 27", "Chrome 22", "IE 11", "Opera 14", "Safari 7", "Android 4.4", "Java 8", "Windows Vista"]
         },

--- a/worker/mozillaEvaluationWorker/mozillaEvaluationWorker.go
+++ b/worker/mozillaEvaluationWorker/mozillaEvaluationWorker.go
@@ -178,7 +178,7 @@ func isBad(c connection.Stored, certsigalg string) (bool, []string) {
 			}
 		}
 
-		if cs.PubKey < old.RsaKeySize {
+		if len(cs.SigAlg) > 5 && cs.SigAlg[0:5] != "ecdsa" && cs.PubKey < old.RsaKeySize {
 			hasBadPK = true
 		}
 
@@ -205,7 +205,7 @@ func isBad(c connection.Stored, certsigalg string) (bool, []string) {
 	}
 
 	if hasBadPK {
-		failures = append(failures, fmt.Sprintf("don't use a public key shorter than %dbits", old.RsaKeySize))
+		failures = append(failures, fmt.Sprintf("don't use a public key shorter than %.0fbits", old.RsaKeySize))
 		isBad = true
 	}
 

--- a/worker/mozillaEvaluationWorker/mozillaEvaluationWorker.go
+++ b/worker/mozillaEvaluationWorker/mozillaEvaluationWorker.go
@@ -108,7 +108,6 @@ func Evaluate(connInfo connection.Stored, certsigalg string) ([]byte, error) {
 
 		ord, ordres := isOrdered(connInfo, modern.Ciphers, "modern")
 		if !ord {
-			ordres = append(ordres, "considering fixing ciphers ordering")
 			results.Failures["modern"] = append(results.Failures["modern"], ordres...)
 		}
 	}
@@ -119,7 +118,6 @@ func Evaluate(connInfo connection.Stored, certsigalg string) ([]byte, error) {
 
 		ord, ordres := isOrdered(connInfo, intermediate.Ciphers, "intermediate")
 		if !ord {
-			ordres = append(ordres, "considering fixing ciphers ordering")
 			results.Failures["intermediate"] = append(results.Failures["intermediate"], ordres...)
 		}
 	}
@@ -130,7 +128,6 @@ func Evaluate(connInfo connection.Stored, certsigalg string) ([]byte, error) {
 
 		ord, ordres := isOrdered(connInfo, old.Ciphers, "old")
 		if !ord {
-			ordres = append(ordres, "considering fixing ciphers ordering")
 			results.Failures["old"] = append(results.Failures["old"], ordres...)
 		}
 	}

--- a/worker/mozillaEvaluationWorker/mozillaEvaluationWorker.go
+++ b/worker/mozillaEvaluationWorker/mozillaEvaluationWorker.go
@@ -278,26 +278,26 @@ func isOld(c connection.Stored, certsigalg string) (bool, []string) {
 	}
 
 	extraCiphers := extra(old.Ciphers, allCiphers)
-	for _, c := range extraCiphers {
-		failures = append(failures, fmt.Sprintf("remove cipher %s", c))
+	if len(extraCiphers) > 0 {
+		failures = append(failures, fmt.Sprintf("remove ciphers %s", strings.Join(extraCiphers, ", ")))
 		isOld = false
 	}
 
 	missingCiphers := extra(allCiphers, old.Ciphers)
-	for _, c := range missingCiphers {
-		failures = append(failures, fmt.Sprintf("add cipher %s", c))
+	if len(missingCiphers) > 0 {
+		failures = append(failures, fmt.Sprintf("consider adding ciphers %s", strings.Join(missingCiphers, ", ")))
 	}
 
 	extraProto := extra(old.TLSVersions, allProtos)
-	for _, p := range extraProto {
-		failures = append(failures, fmt.Sprintf("disable %s protocol", p))
+	if len(extraProto) > 0 {
+		failures = append(failures, fmt.Sprintf("remove protocols %s", strings.Join(extraProto, ", ")))
 		isOld = false
 	}
 
 	missingProto := extra(allProtos, old.TLSVersions)
-	for _, p := range missingProto {
-		failures = append(failures, fmt.Sprintf("add support for %s", p))
-		if p == "SSLv3" {
+	if len(missingProto) > 0 {
+		failures = append(failures, fmt.Sprintf("add protocols %s", strings.Join(missingProto, ", ")))
+		if !contains(missingProto, "SSLv3") {
 			isOld = false
 		}
 	}
@@ -312,7 +312,7 @@ func isOld(c connection.Stored, certsigalg string) (bool, []string) {
 	}
 
 	if !has3DES {
-		failures = append(failures, "add cipher DES-CBC3-SHA")
+		failures = append(failures, "add cipher DES-CBC3-SHA for backward compatibility")
 		isOld = false
 	}
 
@@ -372,26 +372,28 @@ func isIntermediate(c connection.Stored, certsigalg string) (bool, []string) {
 	}
 
 	extraCiphers := extra(intermediate.Ciphers, allCiphers)
-	for _, c := range extraCiphers {
-		failures = append(failures, fmt.Sprintf("remove cipher %s", c))
+	if len(extraCiphers) > 0 {
+		failures = append(failures, fmt.Sprintf("remove ciphers %s", strings.Join(extraCiphers, ", ")))
 		isIntermediate = false
 	}
 
 	missingCiphers := extra(allCiphers, intermediate.Ciphers)
-	for _, c := range missingCiphers {
-		failures = append(failures, fmt.Sprintf("considering adding cipher %s", c))
+	if len(missingCiphers) > 0 {
+		failures = append(failures, fmt.Sprintf("consider adding ciphers %s", strings.Join(missingCiphers, ", ")))
 	}
 
 	extraProto := extra(intermediate.TLSVersions, allProtos)
-	for _, p := range extraProto {
-		failures = append(failures, fmt.Sprintf("disable %s protocol", p))
+	if len(extraProto) > 0 {
+		failures = append(failures, fmt.Sprintf("remove protocols %s", strings.Join(extraProto, ", ")))
 		isIntermediate = false
 	}
 
 	missingProto := extra(allProtos, intermediate.TLSVersions)
-	for _, p := range missingProto {
-		failures = append(failures, fmt.Sprintf("enable %s protocol", p))
-		isIntermediate = false
+	if len(missingProto) > 0 {
+		failures = append(failures, fmt.Sprintf("add protocols %s", strings.Join(missingProto, ", ")))
+		if !contains(missingProto, "TLSv1") {
+			isIntermediate = false
+		}
 	}
 
 	if !c.ServerSide {
@@ -459,26 +461,28 @@ func isModern(c connection.Stored, certsigalg string) (bool, []string) {
 	}
 
 	extraCiphers := extra(modern.Ciphers, allCiphers)
-	for _, c := range extraCiphers {
-		failures = append(failures, fmt.Sprintf("remove cipher %s", c))
+	if len(extraCiphers) > 0 {
+		failures = append(failures, fmt.Sprintf("remove ciphers %s", strings.Join(extraCiphers, ", ")))
 		isModern = false
 	}
 
 	missingCiphers := extra(allCiphers, modern.Ciphers)
-	for _, c := range missingCiphers {
-		failures = append(failures, fmt.Sprintf("considering adding cipher %s", c))
+	if len(missingCiphers) > 0 {
+		failures = append(failures, fmt.Sprintf("consider adding ciphers %s", strings.Join(missingCiphers, ", ")))
 	}
 
 	extraProto := extra(modern.TLSVersions, allProtos)
-	for _, p := range extraProto {
-		failures = append(failures, fmt.Sprintf("disable %s protocol", p))
+	if len(extraProto) > 0 {
+		failures = append(failures, fmt.Sprintf("remove protocols %s", strings.Join(extraProto, ", ")))
 		isModern = false
 	}
 
 	missingProto := extra(allProtos, modern.TLSVersions)
-	for _, p := range missingProto {
-		failures = append(failures, fmt.Sprintf("enable %s protocol", p))
-		isModern = false
+	if len(missingProto) > 0 {
+		failures = append(failures, fmt.Sprintf("add protocols %s", strings.Join(missingProto, ", ")))
+		if !contains(missingProto, "TLSv1.2") {
+			isModern = false
+		}
 	}
 
 	if !c.ServerSide {

--- a/worker/mozillaEvaluationWorker/mozillaEvaluationWorker_test.go
+++ b/worker/mozillaEvaluationWorker/mozillaEvaluationWorker_test.go
@@ -19,7 +19,7 @@ func TestLevels(t *testing.T) {
 		{
 			expectedLevel: "modern",
 			cipherscan:    `{"scanIP":"62.210.76.92","serverside":true,"ciphersuite":[{"cipher":"ECDHE-RSA-AES128-GCM-SHA256","protocols":["TLSv1.2"],"pubkey":2048,"sigalg":"sha256WithRSAEncryption","ticket_hint":"300","ocsp_stapling":true,"pfs":"ECDH,P-384,384bits","curves":["secp384r1"]},{"cipher":"ECDHE-RSA-AES256-GCM-SHA384","protocols":["TLSv1.2"],"pubkey":2048,"sigalg":"sha256WithRSAEncryption","ticket_hint":"300","ocsp_stapling":true,"pfs":"ECDH,P-384,384bits","curves":["secp384r1"]},{"cipher":"ECDHE-RSA-AES128-SHA256","protocols":["TLSv1.2"],"pubkey":2048,"sigalg":"sha256WithRSAEncryption","ticket_hint":"300","ocsp_stapling":true,"pfs":"ECDH,P-384,384bits","curves":["secp384r1"]},{"cipher":"ECDHE-RSA-AES256-SHA384","protocols":["TLSv1.2"],"pubkey":2048,"sigalg":"sha256WithRSAEncryption","ticket_hint":"300","ocsp_stapling":true,"pfs":"ECDH,P-384,384bits","curves":["secp384r1"]}]}`,
-			certSignature: "ECDSAWithSHA384",
+			certSignature: "ECDSAWithSHA256",
 		},
 		{
 			expectedLevel: "intermediate",
@@ -72,17 +72,17 @@ func TestOrderings(t *testing.T) {
 			expectedLevel:    "modern",
 			expectedFailures: []string{`considering fixing ciphers ordering`},
 			cipherscan:       `{"scanIP":"62.210.76.92","serverside":true,"ciphersuite":[{"cipher":"ECDHE-RSA-AES128-GCM-SHA256","protocols":["TLSv1.2"],"pubkey":2048,"sigalg":"sha256WithRSAEncryption","ticket_hint":"300","ocsp_stapling":true,"pfs":"ECDH,P-384,384bits","curves":["secp384r1"]},{"cipher":"ECDHE-RSA-AES256-GCM-SHA384","protocols":["TLSv1.2"],"pubkey":2048,"sigalg":"sha256WithRSAEncryption","ticket_hint":"300","ocsp_stapling":true,"pfs":"ECDH,P-384,384bits","curves":["secp384r1"]}]}`,
-			certSignature:    "ECDSAWithSHA384",
+			certSignature:    "ECDSAWithSHA256",
 		},
 		{
 			expectedLevel:    "modern",
-			expectedFailures: []string{`enable Perfect Forward Secrecy with a curve of at least 384bits, don't use DHE`, `remove cipher DHE-RSA-AES128-GCM-SHA256`},
+			expectedFailures: []string{`enable Perfect Forward Secrecy with a curve of at least 256bits, don't use DHE`, `remove cipher DHE-RSA-AES128-GCM-SHA256`},
 			cipherscan:       `{"scanIP":"62.210.76.92","serverside":true,"ciphersuite":[{"cipher":"ECDHE-RSA-AES128-GCM-SHA256","protocols":["TLSv1.2"],"pubkey":2048,"sigalg":"sha256WithRSAEncryption","ticket_hint":"300","ocsp_stapling":true,"pfs":"ECDH,P-384,384bits","curves":["secp384r1"]},{"cipher":"ECDHE-RSA-AES256-GCM-SHA384","protocols":["TLSv1.2"],"pubkey":2048,"sigalg":"sha256WithRSAEncryption","ticket_hint":"300","ocsp_stapling":true,"pfs":"ECDH,P-384,384bits","curves":["secp384r1"]},{"cipher":"DHE-RSA-AES128-GCM-SHA256","protocols":["TLSv1.2"],"pubkey":2048,"sigalg":"sha1WithRSAEncryption","ticket_hint":"None","ocsp_stapling":true,"pfs":"DH,1024bits"}]}`,
-			certSignature:    "ECDSAWithSHA384",
+			certSignature:    "ECDSAWithSHA256",
 		},
 		{
 			expectedLevel:    "modern",
-			expectedFailures: []string{`sha256WithRSAEncryption is not a modern certificate signature, use ecdsa-with-SHA384`},
+			expectedFailures: []string{`sha256WithRSAEncryption is not a modern certificate signature, use ecdsa-with-SHA256`, `considering adding cipher ECDHE-ECDSA-CHACHA20-POLY1305`},
 			cipherscan:       `{"scanIP":"62.210.76.92","serverside":true,"ciphersuite":[{"cipher":"ECDHE-RSA-AES128-GCM-SHA256","protocols":["TLSv1.2"],"pubkey":2048,"sigalg":"sha256WithRSAEncryption","ticket_hint":"300","ocsp_stapling":true,"pfs":"ECDH,P-384,384bits","curves":["secp384r1"]},{"cipher":"ECDHE-RSA-AES256-GCM-SHA384","protocols":["TLSv1.2"],"pubkey":2048,"sigalg":"sha256WithRSAEncryption","ticket_hint":"300","ocsp_stapling":true,"pfs":"ECDH,P-384,384bits","curves":["secp384r1"]}]}`,
 			certSignature:    "SHA256WithRSA",
 		},
@@ -91,6 +91,12 @@ func TestOrderings(t *testing.T) {
 			expectedFailures: []string{`sha1WithRSAEncryption is not an intermediate certificate signature, use sha256WithRSAEncryption`},
 			cipherscan:       `{"scanIP":"62.210.76.92","serverside":true,"ciphersuite":[{"cipher":"ECDHE-RSA-AES128-GCM-SHA256","protocols":["TLSv1.2"],"pubkey":2048,"sigalg":"sha256WithRSAEncryption","ticket_hint":"300","ocsp_stapling":true,"pfs":"ECDH,P-384,384bits","curves":["secp384r1"]},{"cipher":"ECDHE-RSA-AES256-GCM-SHA384","protocols":["TLSv1.2"],"pubkey":2048,"sigalg":"sha256WithRSAEncryption","ticket_hint":"300","ocsp_stapling":true,"pfs":"ECDH,P-384,384bits","curves":["secp384r1"]}]}`,
 			certSignature:    "SHA1WithRSA",
+		},
+		{
+			expectedLevel:    "intermediate",
+			expectedFailures: []string{`remove cipher RC4-MD5`, `disable SSLv3 protocol`, `enable TLSv1.1 protocol`},
+			cipherscan:       `{"scanIP":"62.210.76.92","serverside":true,"ciphersuite":[{"cipher":"RC4-MD5","protocols":["TLSv1.2", "SSLv3"],"pubkey":2048,"sigalg":"sha256WithRSAEncryption","ticket_hint":"300","ocsp_stapling":true,"pfs":"ECDH,P-384,384bits","curves":["secp384r1"]}]}`,
+			certSignature:    "MD5WithRSA",
 		},
 	}
 	for _, tp := range tps {

--- a/worker/mozillaEvaluationWorker/mozillaEvaluationWorker_test.go
+++ b/worker/mozillaEvaluationWorker/mozillaEvaluationWorker_test.go
@@ -87,10 +87,11 @@ func TestOrderings(t *testing.T) {
 			certSignature:    "ECDSAWithSHA256",
 		},
 		{
-			expectedLevel:    "modern",
-			expectedFailures: []string{`sha256WithRSAEncryption is not a modern certificate signature, use ecdsa-with-SHA256`, `considering adding cipher ECDHE-ECDSA-CHACHA20-POLY1305`},
-			cipherscan:       `{"scanIP":"62.210.76.92","serverside":true,"ciphersuite":[{"cipher":"ECDHE-RSA-AES128-GCM-SHA256","protocols":["TLSv1.2"],"pubkey":2048,"sigalg":"sha256WithRSAEncryption","ticket_hint":"300","ocsp_stapling":true,"pfs":"ECDH,P-384,384bits","curves":["secp384r1"]},{"cipher":"ECDHE-RSA-AES256-GCM-SHA384","protocols":["TLSv1.2"],"pubkey":2048,"sigalg":"sha256WithRSAEncryption","ticket_hint":"300","ocsp_stapling":true,"pfs":"ECDH,P-384,384bits","curves":["secp384r1"]}]}`,
-			certSignature:    "SHA256WithRSA",
+			expectedLevel: "modern",
+			expectedFailures: []string{`sha256WithRSAEncryption is not a modern certificate signature, use ecdsa-with-SHA256`,
+				`consider adding ciphers ECDHE-ECDSA-AES256-GCM-SHA384, ECDHE-ECDSA-CHACHA20-POLY1305, ECDHE-RSA-CHACHA20-POLY1305, ECDHE-ECDSA-AES128-GCM-SHA256, ECDHE-ECDSA-AES256-SHA384, ECDHE-RSA-AES256-SHA384, ECDHE-ECDSA-AES128-SHA256, ECDHE-RSA-AES128-SHA256`},
+			cipherscan:    `{"scanIP":"62.210.76.92","serverside":true,"ciphersuite":[{"cipher":"ECDHE-RSA-AES128-GCM-SHA256","protocols":["TLSv1.2"],"pubkey":2048,"sigalg":"sha256WithRSAEncryption","ticket_hint":"300","ocsp_stapling":true,"pfs":"ECDH,P-384,384bits","curves":["secp384r1"]},{"cipher":"ECDHE-RSA-AES256-GCM-SHA384","protocols":["TLSv1.2"],"pubkey":2048,"sigalg":"sha256WithRSAEncryption","ticket_hint":"300","ocsp_stapling":true,"pfs":"ECDH,P-384,384bits","curves":["secp384r1"]}]}`,
+			certSignature: "SHA256WithRSA",
 		},
 		{
 			expectedLevel:    "intermediate",
@@ -100,7 +101,7 @@ func TestOrderings(t *testing.T) {
 		},
 		{
 			expectedLevel:    "intermediate",
-			expectedFailures: []string{`remove cipher RC4-MD5`, `disable SSLv3 protocol`, `enable TLSv1.1 protocol`},
+			expectedFailures: []string{`remove cipher RC4-MD5`, `remove protocols SSLv3`, `add protocols TLSv1.1, TLSv1`},
 			cipherscan:       `{"scanIP":"62.210.76.92","serverside":true,"ciphersuite":[{"cipher":"RC4-MD5","protocols":["TLSv1.2", "SSLv3"],"pubkey":2048,"sigalg":"sha256WithRSAEncryption","ticket_hint":"300","ocsp_stapling":true,"pfs":"ECDH,P-384,384bits","curves":["secp384r1"]}]}`,
 			certSignature:    "MD5WithRSA",
 		},

--- a/worker/mozillaEvaluationWorker/mozillaEvaluationWorker_test.go
+++ b/worker/mozillaEvaluationWorker/mozillaEvaluationWorker_test.go
@@ -69,6 +69,12 @@ func TestLevels(t *testing.T) {
 func TestOrderings(t *testing.T) {
 	var tps = []testParams{
 		{
+			expectedLevel:    "bad",
+			expectedFailures: []string{`don't use a public key shorter than 2048bits`},
+			cipherscan:       `{"scanIP":"62.210.76.92","serverside":true,"ciphersuite":[{"cipher":"ECDHE-RSA-AES128-GCM-SHA256","protocols":["TLSv1.2"],"pubkey":512,"sigalg":"sha256WithRSAEncryption","ticket_hint":"300","ocsp_stapling":true,"pfs":"ECDH,P-384,384bits","curves":["secp384r1"]}]}`,
+			certSignature:    "MD5WithRSA",
+		},
+		{
 			expectedLevel:    "modern",
 			expectedFailures: []string{`considering fixing ciphers ordering`},
 			cipherscan:       `{"scanIP":"62.210.76.92","serverside":true,"ciphersuite":[{"cipher":"ECDHE-RSA-AES128-GCM-SHA256","protocols":["TLSv1.2"],"pubkey":2048,"sigalg":"sha256WithRSAEncryption","ticket_hint":"300","ocsp_stapling":true,"pfs":"ECDH,P-384,384bits","curves":["secp384r1"]},{"cipher":"ECDHE-RSA-AES256-GCM-SHA384","protocols":["TLSv1.2"],"pubkey":2048,"sigalg":"sha256WithRSAEncryption","ticket_hint":"300","ocsp_stapling":true,"pfs":"ECDH,P-384,384bits","curves":["secp384r1"]}]}`,

--- a/worker/mozillaEvaluationWorker/mozillaEvaluationWorker_test.go
+++ b/worker/mozillaEvaluationWorker/mozillaEvaluationWorker_test.go
@@ -76,7 +76,7 @@ func TestOrderings(t *testing.T) {
 		},
 		{
 			expectedLevel:    "modern",
-			expectedFailures: []string{`considering fixing ciphers ordering`},
+			expectedFailures: []string{`fix ciphersuite ordering, use recommended modern ciphersuite`},
 			cipherscan:       `{"scanIP":"62.210.76.92","serverside":true,"ciphersuite":[{"cipher":"ECDHE-RSA-AES128-GCM-SHA256","protocols":["TLSv1.2"],"pubkey":2048,"sigalg":"sha256WithRSAEncryption","ticket_hint":"300","ocsp_stapling":true,"pfs":"ECDH,P-384,384bits","curves":["secp384r1"]},{"cipher":"ECDHE-RSA-AES256-GCM-SHA384","protocols":["TLSv1.2"],"pubkey":2048,"sigalg":"sha256WithRSAEncryption","ticket_hint":"300","ocsp_stapling":true,"pfs":"ECDH,P-384,384bits","curves":["secp384r1"]}]}`,
 			certSignature:    "ECDSAWithSHA256",
 		},


### PR DESCRIPTION
do not merge yet, testing in staging first

This set of patches improves the evaluation worker and add some stricter controls on the number of scanners that run in parallel. We also store a number column in the `scans` table to track a count of retries on scans that don't succeeds.

This last change requires a DB change:
```sql
ALTER TABLE scans ADD COLUMN attempts integer;
```