### PR TITLE
TLS configuration from static resource

### DIFF
--- a/worker/mozillaEvaluationWorker/configurations.go
+++ b/worker/mozillaEvaluationWorker/configurations.go
@@ -1,5 +1,6 @@
 package mozillaEvaluationWorker
 
+//saved TLS configurations
 var ServerSideTLSConfiguration = `{
     "configurations": {
         "modern": {
@@ -25,7 +26,7 @@ var ServerSideTLSConfiguration = `{
             "dh_param_size": null,
             "ecdh_param_size": 256,
             "hsts_min_age": 15768000,
-            "oldest_clients": [ "Firefox 27", "Chrome 22", "IE 11", "Opera 14", "Safari 7", "Android 4.4", "Java 8", "Windows Vista"]
+            "oldest_clients": [ "Firefox 27", "Chrome 30", "IE 11 on Windows 7", "Edge 1", "Opera 17", "Safari 9", "Android 5.0", "Java 8"]
         },
         "intermediate": {
             "openssl_ciphersuites": "ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-RSA-AES256-SHA:ECDHE-ECDSA-DES-CBC3-SHA:ECDHE-RSA-DES-CBC3-SHA:EDH-RSA-DES-CBC3-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:DES-CBC3-SHA:!DSS",


### PR DESCRIPTION
The evaluation worker gets the configuration from https://statics.tls.security.mozilla.org/server-side-tls-conf-4.0.json .

In case they are not available at that URL or the unmarshalling fails for any reason the ones saved locally are used.

Would it be worth it removing the version from the file, so going to server-side-tls-conf.json ? ( since the version is in the file and the evaluation worker should always get the latest without recompiling )