### PR TITLE
Create Dockerfile to try and run tlsobs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM golang:1.7
+ENV GOPATH /go/src/app
+ENV PATH $GOPATH/bin:$PATH
+RUN mkdir -p $GOPATH
+WORKDIR $GOPATH
+RUN go get github.com/mozilla/tls-observatory/tlsobs
+CMD tlsobs


### PR DESCRIPTION
On CentOS 7, golang is still at version 1.6. I wanted to run tlsobs on it, so I've defined a Dockerfile in order to be able to "go get" the github tls-observatory repo with the right dependencies installed. After building the container, I was able to successfully run it. Details provided below.

Description of commit: Create a container with all dependencies to run the tlsobs command.

To build:
docker build -t tls-observatory .

To run:
docker run -it tls-observatory tlsobs twitter.com