### PR TITLE
Add Subject+SPKI hashing to certificate parsing

### DIFF
--- a/certificate/certificate.go
+++ b/certificate/certificate.go
@@ -45,10 +45,11 @@ type Certificate struct {
 }
 
 type Hashes struct {
-	MD5       string `json:"md5,omitempty"`
-	SHA1      string `json:"sha1,omitempty"`
-	SHA256    string `json:"sha256,omitempty"`
-	PKPSHA256 string `json:"pin-sha256,omitempty"`
+	MD5               string `json:"md5,omitempty"`
+	SHA1              string `json:"sha1,omitempty"`
+	SHA256            string `json:"sha256,omitempty"`
+	SHA256SubjectSPKI string `json:"sha256_subject_spki,omitempty"`
+	PKPSHA256         string `json:"pin-sha256,omitempty"`
 }
 
 type Validity struct {
@@ -165,6 +166,13 @@ var PublicKeyAlgorithm = [...]string{
 	"RSA",
 	"DSA",
 	"ECDSA",
+}
+
+func SHA256SubjectSPKI(cert *x509.Certificate) string {
+	h := sha256.New()
+	h.Write(cert.RawSubject)
+	h.Write(cert.RawSubjectPublicKeyInfo)
+	return fmt.Sprintf("%X", h.Sum(nil))
 }
 
 func PKPSHA256Hash(cert *x509.Certificate) string {
@@ -463,6 +471,7 @@ func CertToStored(cert *x509.Certificate, parentSignature, domain, ip string, TS
 	stored.Hashes.MD5 = MD5Hash(cert.Raw)
 	stored.Hashes.SHA1 = SHA1Hash(cert.Raw)
 	stored.Hashes.SHA256 = SHA256Hash(cert.Raw)
+	stored.Hashes.SHA256SubjectSPKI = SHA256SubjectSPKI(cert)
 	stored.Hashes.PKPSHA256 = PKPSHA256Hash(cert)
 
 	stored.Raw = base64.StdEncoding.EncodeToString(cert.Raw)

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -2,6 +2,7 @@ CREATE TABLE certificates(
 	id	        				serial primary key,
 	sha1_fingerprint	        varchar NOT NULL,
 	sha256_fingerprint	    	varchar NOT NULL,
+    sha256_subject_spki         varchar NOT NULL,
 	pkp_sha256			    	varchar NOT NULL,
 	serial_number				varchar NULL,
 	version						integer NULL,

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -1,72 +1,72 @@
 CREATE TABLE certificates(
-	id	        				serial primary key,
-	sha1_fingerprint	        varchar NOT NULL,
-	sha256_fingerprint	    	varchar NOT NULL,
+    id                          serial primary key,
+    sha1_fingerprint            varchar NOT NULL,
+    sha256_fingerprint          varchar NOT NULL,
     sha256_subject_spki         varchar NOT NULL,
-	pkp_sha256			    	varchar NOT NULL,
-	serial_number				varchar NULL,
-	version						integer NULL,
-	domains 					varchar NULL,
-	subject						jsonb NULL,
-	issuer				        jsonb NULL,
-	is_ca						bool NULL,
-	not_valid_before	        timestamp NULL,
-	not_valid_after				timestamp NULL,
-	first_seen					timestamp NULL,
-	last_seen					timestamp NULL,
-	key_alg					    varchar NULL,
-	key						    jsonb NULL,
-	x509_basicConstraints		varchar NULL,
-	x509_crlDistributionPoints 	jsonb NULL,
-	x509_extendedKeyUsage		jsonb NULL,
-	x509_authorityKeyIdentifier	varchar NULL,
-	x509_subjectKeyIdentifier	varchar NULL,
-	x509_keyUsage				jsonb NULL,
-	x509_certificatePolicies 	varchar NULL,
-	x509_authorityInfoAccess 	varchar NULL,
-	x509_subjectAltName			jsonb NULL,
-	x509_issuerAltName	        varchar NULL,
-	signature_algo		        varchar NULL,
-	in_ubuntu_root_store		bool NULL,
-	in_mozilla_root_store		bool NULL,
-	in_microsoft_root_store	    bool NULL,
-	in_apple_root_store			bool NULL,
-	in_android_root_store	    bool NULL,
-	is_revoked			        bool NULL,
-	revoked_at			        timestamp NULL,
-	raw_cert					varchar NOT NULL
+    pkp_sha256                  varchar NOT NULL,
+    serial_number               varchar NULL,
+    version                     integer NULL,
+    domains                     varchar NULL,
+    subject                     jsonb NULL,
+    issuer                      jsonb NULL,
+    is_ca                       bool NULL,
+    not_valid_before            timestamp NULL,
+    not_valid_after             timestamp NULL,
+    first_seen                  timestamp NULL,
+    last_seen                   timestamp NULL,
+    key_alg                     varchar NULL,
+    key                         jsonb NULL,
+    x509_basicConstraints       varchar NULL,
+    x509_crlDistributionPoints  jsonb NULL,
+    x509_extendedKeyUsage       jsonb NULL,
+    x509_authorityKeyIdentifier varchar NULL,
+    x509_subjectKeyIdentifier   varchar NULL,
+    x509_keyUsage               jsonb NULL,
+    x509_certificatePolicies    varchar NULL,
+    x509_authorityInfoAccess    varchar NULL,
+    x509_subjectAltName         jsonb NULL,
+    x509_issuerAltName          varchar NULL,
+    signature_algo              varchar NULL,
+    in_ubuntu_root_store        bool NULL,
+    in_mozilla_root_store       bool NULL,
+    in_microsoft_root_store     bool NULL,
+    in_apple_root_store         bool NULL,
+    in_android_root_store       bool NULL,
+    is_revoked                  bool NULL,
+    revoked_at                  timestamp NULL,
+    raw_cert                    varchar NOT NULL
 );
 CREATE INDEX certificates_sha256_fingerprint_idx ON certificates(sha256_fingerprint);
 
 CREATE TABLE trust (
-	id						    serial primary key,
-	cert_id		                integer references certificates(id) NOT NULL,
-	issuer_id		            integer references certificates(id) NOT NULL,
-	timestamp				    timestamp NOT NULL,
-	trusted_ubuntu	            bool NULL,
-	trusted_mozilla	            bool NULL,
-	trusted_microsoft		    bool NULL,
-	trusted_apple		        bool NULL,
-	trusted_android			    bool NULL,
-	is_current				    bool NOT NULL
+    id                serial primary key,
+    cert_id           integer references certificates(id) NOT NULL,
+    issuer_id         integer references certificates(id) NOT NULL,
+    timestamp         timestamp NOT NULL,
+    trusted_ubuntu    bool NULL,
+    trusted_mozilla   bool NULL,
+    trusted_microsoft bool NULL,
+    trusted_apple     bool NULL,
+    trusted_android   bool NULL,
+    is_current        bool NOT NULL
 );
 CREATE INDEX trust_cert_id_idx ON trust(cert_id);
 CREATE INDEX trust_is_current_idx ON trust(is_current);
 
 CREATE TABLE scans(
-	id	        				serial primary key,
-	timestamp	        		timestamp NOT NULL,
-	target						varchar NOT NULL,
-	replay 						integer NULL,
-	has_tls						bool NOT NULL,
-	cert_id						integer references certificates(id) NULL,
-	trust_id					integer references trust(id) NULL,
-	is_valid			        bool NOT NULL,
-	completion_perc				integer NOT NULL,
-	validation_error	        varchar NOT NULL,
-	conn_info					jsonb NOT NULL,
-	ack 						bool NOT NULL,
-	attempts					integer NULL
+    id               serial primary key,
+    timestamp        timestamp NOT NULL,
+    target           varchar NOT NULL,
+    replay           integer NULL,
+    has_tls          bool NOT NULL,
+    cert_id          integer references certificates(id) NULL,
+    trust_id         integer references trust(id) NULL,
+    is_valid         bool NOT NULL,
+    completion_perc  integer NOT NULL,
+    validation_error varchar NOT NULL,
+    conn_info        jsonb NOT NULL,
+    ack              bool NOT NULL,
+    attempts         integer NULL
 );
 CREATE INDEX scans_completion_attempts_idx ON scans(completion_perc, attempts);
 CREATE INDEX scans_ack_idx ON scans(ack);
@@ -74,10 +74,10 @@ CREATE INDEX scans_target_idx ON scans(target);
 CREATE INDEX scans_timestamp_idx ON scans(timestamp);
 
 CREATE TABLE analysis(
-	id					        serial primary key,
-	scan_id						integer references scans(id),
-	worker_name			        varchar NOT NULL,
-	output						jsonb NULL
+    id          serial primary key,
+    scan_id     integer references scans(id),
+    worker_name varchar NOT NULL,
+    output      jsonb NULL
 );
 CREATE INDEX analysis_scan_id_idx ON analysis(scan_id);
 

--- a/tools/fixSHA256SubjectSPKI.go
+++ b/tools/fixSHA256SubjectSPKI.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"crypto/x509"
+	"encoding/base64"
+	"fmt"
+	"os"
+
+	"github.com/mozilla/tls-observatory/certificate"
+	"github.com/mozilla/tls-observatory/database"
+)
+
+func main() {
+	db, err := database.RegisterConnection(
+		os.Getenv("TLSOBS_POSTGRESDB"),
+		os.Getenv("TLSOBS_POSTGRESUSER"),
+		os.Getenv("TLSOBS_POSTGRESPASS"),
+		os.Getenv("TLSOBS_POSTGRES"),
+		"require")
+	defer db.Close()
+	if err != nil {
+		panic(err)
+	}
+	// batch side: do 100 certs at a time
+	limit := 100
+	batch := 0
+	for {
+		fmt.Printf("\nProcessing batch %d to %d: ", batch*limit, batch*limit+limit)
+		rows, err := db.Query(`SELECT id, raw_cert
+					FROM certificates
+					WHERE sha256_subject_spki IS NULL
+					ORDER BY id ASC LIMIT $1`, limit)
+		if rows != nil {
+			defer rows.Close()
+		}
+		if err != nil {
+			panic(fmt.Errorf("Error while retrieving certs: '%v'", err))
+		}
+		i := 0
+		for rows.Next() {
+			i++
+			var raw string
+			var id int64
+			err = rows.Scan(&id, &raw)
+			if err != nil {
+				fmt.Println("error while parsing cert", id, ":", err)
+				continue
+			}
+			certdata, err := base64.StdEncoding.DecodeString(raw)
+			if err != nil {
+				fmt.Println("error decoding base64 of cert", id, ":", err)
+				continue
+			}
+			c, err := x509.ParseCertificate(certdata)
+			if err != nil {
+				fmt.Println("error while x509 parsing cert", id, ":", err)
+				continue
+			}
+			_, err = db.Exec(`UPDATE certificates SET sha256_subject_spki=$1 WHERE id=$2`,
+				certificate.SHA256SubjectSPKI(c), id)
+			if err != nil {
+				fmt.Println("error while updating cert", id, "in database:", err)
+			}
+		}
+		if i == 0 {
+			fmt.Println("done!")
+			break
+		}
+		//offset += limit
+		batch++
+	}
+}


### PR DESCRIPTION
This patch adds support for computing a hash of the raw subject and spki fields of a certificate and storing it in database. The new field is called `sha256_subject_spki` in both the DB and JSON output. It represents the hexadecimal string of the SHA256 of DER encoded Subject and SPKI fields.

Before deploying this to prod, we'll need to run this query: `ALTER TABLE certificates ADD COLUMN sha256_subject_spki;`

Then run the tool to update existing rows: `go run fixSHA256SubjectSPKI.go`

And finally set the `NOT NULL` condition on the column: `ALTER TABLE certificates ALTER COLUMN sha256_subject_spki SET NOT NULL;`

r? @mozkeeler
f? @sleevi (and thanks for the code snippet)