### PR TITLE
Revert "sort analysis array before showing it. fixes #131"

### DIFF
--- a/tlsobs/main.go
+++ b/tlsobs/main.go
@@ -261,7 +261,6 @@ func printAnalysis(ars []database.Analysis) {
 		return
 	}
 	fmt.Println("\n--- Analyzers ---")
-	sortAnalysis(ars)
 	for _, a := range ars {
 		var (
 			results []string
@@ -284,22 +283,6 @@ func printAnalysis(ars []database.Analysis) {
 		}
 		for _, result := range results {
 			fmt.Println(result)
-		}
-	}
-}
-
-func sortAnalysis(ars []database.Analysis) {
-	//Perform a simple bubblesort of the Analysis slice using the Analyzer name
-	swap := true
-	for swap {
-		swap = false
-		for i := 0; i < len(ars)-1; i++ {
-			if ars[i+1].Analyzer < ars[i].Analyzer {
-				tmp := ars[i+1]
-				ars[i+1] = ars[i]
-				ars[i] = tmp
-				swap = true
-			}
 		}
 	}
 }


### PR DESCRIPTION
Reverts mozilla/tls-observatory#150

So, I just realized this isn't what we want. We want to sort the analysis array in the JSON returned by the API, not just sort the display in the tlsobs command line.