### PR TITLE
PostCertificateHandler is not able to handle empty filenames

### DIFF
--- a/tools/pullCTLogs.go
+++ b/tools/pullCTLogs.go
@@ -83,7 +83,7 @@ func main() {
 			// create a mime/multipart form with the certificate
 			var b bytes.Buffer
 			w := multipart.NewWriter(&b)
-			fw, err := w.CreateFormFile("certificate", cert.Subject.CommonName)
+			fw, err := w.CreateFormFile("certificate", certificate.SHA256Hash(cert.Raw))
 			if err != nil {
 				log.Fatal(err)
 			}


### PR DESCRIPTION
change the filename to the hash of the certificate, that is always non-empty.