### PR TITLE
Added truststore endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,21 @@ curl https://tls-observatory.services.mozilla.com/api/v1/paths?id=1
 
 **Output**: a `json` document containing the paths document. Each entry in the path contains the current certificate and an array of parents, if any exist.
 
+#### GET /api/v1/truststore
+
+Retrieve all the certificates in a given truststore.
+
+```bash
+curl https://tls-observatory.services.mozilla.com/api/v1/truststore?store=mozilla&format=pem
+```
+
+**Parameters**:
+
+* `store` is the store to retrieve certificates from. "mozilla", "android", "apple", "microsoft" and "ubuntu" are allowed.
+* `format`, either "pem" or "json". 
+
+**Output**: if `format` is pem, a series of PEM-format certificates. If `format` is json, a json array of certificate objects, each with the same format of `/api/v1/certificate`.
+
 ### Database Queries
 
 ### Find certificates signed by CAs identified by their SHA256 fingerprint

--- a/tlsobs-api/handlers.go
+++ b/tlsobs-api/handlers.go
@@ -482,17 +482,17 @@ func TruststoreHandler(w http.ResponseWriter, r *http.Request) {
 			}
 			fingerprint := sha256.Sum256(x509.Raw)
 			buffer.Write([]byte(fmt.Sprintf(`# Certificate "%s"
-# Issuer: CN=%s,OU=%s,O=%s,C=%s
+# Issuer: %s
 # Serial Number: %x
-# Subject: CN=%s,OU=%s,O=%s,C=%s
+# Subject: %s
 # Not Valid Before: %s
 # Not Valid After : %s
 # Fingerprint (SHA256): %x
 `,
 				x509.Subject.CommonName,
-				x509.Issuer.CommonName, x509.Issuer.OrganizationalUnit, x509.Issuer.Organization, x509.Issuer.Country,
+				cert.Issuer.String(),
 				x509.SerialNumber,
-				x509.Subject.CommonName, x509.Subject.OrganizationalUnit, x509.Subject.Organization, x509.Subject.Country,
+				cert.Subject.String(),
 				x509.NotBefore,
 				x509.NotAfter,
 				fingerprint,

--- a/tlsobs-api/handlers.go
+++ b/tlsobs-api/handlers.go
@@ -484,7 +484,6 @@ func TruststoreHandler(w http.ResponseWriter, r *http.Request) {
 				httpError(w, http.StatusInternalServerError, "Error PEM-encoding certificate")
 				return
 			}
-			buffer.Write([]byte{'\n'})
 		}
 		bufferLen := buffer.Len()
 		w.Header().Set("Content-Type", "text/plain")

--- a/tlsobs-api/router.go
+++ b/tlsobs-api/router.go
@@ -96,4 +96,10 @@ var routes = Routes{
 		"/api/v1/__heartbeat__",
 		HeartbeatHandler,
 	},
+	Route{
+		"Truststore",
+		"GET",
+		"/api/v1/truststore",
+		TruststoreHandler,
+	},
 }

--- a/tlsobs-api/router.go
+++ b/tlsobs-api/router.go
@@ -65,6 +65,12 @@ var routes = Routes{
 		"/api/v1/paths",
 		PathsHandler,
 	},
+	Route{
+		"Truststore",
+		"GET",
+		"/api/v1/truststore",
+		TruststoreHandler,
+	},
 	// CORS preflight endpoints
 	Route{
 		"CORS Preflight",
@@ -91,15 +97,15 @@ var routes = Routes{
 		PreflightHandler,
 	},
 	Route{
+		"CORS Preflight",
+		"OPTIONS",
+		"/api/v1/truststore",
+		PreflightHandler,
+	},
+	Route{
 		"Heartbeat",
 		"GET",
 		"/api/v1/__heartbeat__",
 		HeartbeatHandler,
-	},
-	Route{
-		"Truststore",
-		"GET",
-		"/api/v1/truststore",
-		TruststoreHandler,
 	},
 }


### PR DESCRIPTION
Locally I saw some differences between https://tls-observatory.services.mozilla.com/api/v1/certificate?id=42 and http://localhost/api/v1/certificate?id=42. I'm not exactly sure why this is, but I wanted to mention it just in case.

Missing:
- [x] API documentation in README