### PR TITLE
Build ev-checker as root

### DIFF
--- a/tools/Dockerfile-scanner
+++ b/tools/Dockerfile-scanner
@@ -17,11 +17,11 @@ RUN groupadd -r tlsobs && useradd -r -g tlsobs tlsobs
 ADD . /go/src/$PROJECT
 RUN chown tlsobs /go -R
 
-# switch to tlsobs user
-USER tlsobs
-
 RUN git clone https://github.com/mozkeeler/ev-checker.git
 RUN cd ev-checker && make && mv ./ev-checker /usr/local/bin/ && cd .. && rm -rf ev-checker
+
+# switch to tlsobs user
+USER tlsobs
 
 RUN go generate $PROJECT/worker/mozillaGradingWorker
 


### PR DESCRIPTION
ef7edb7dd820e38b9713425671765147d144bd4d broke the scanner docker container because we can't move the binary to /usr/local/bin as non-root.