### PR TITLE
Minor cleanups (and XSS fix)

### DIFF
--- a/static/certsplainer.html
+++ b/static/certsplainer.html
@@ -25,8 +25,8 @@
             <tr><td>serial number</td><td id="serialNumber"></td></tr>
             <tr><td>subject</td><td id="subject"></td></tr>
             <tr><td>issuer</td><td id="issuer"></td></tr>
-            <tr><td>not before</td><td id="notBefore"</td></tr>
-            <tr><td>not after</td><td id="notAfter"</td></tr>
+            <tr><td>not before</td><td id="notBefore"></td></tr>
+            <tr><td>not after</td><td id="notAfter"></td></tr>
             <tr><td>signature algorithm</td><td id="signatureAlgorithm"></td></tr>
             <tr id="keySizeRow"><td>key size</td><td id="keySize"></td></tr>
             <tr id="exponentRow"><td>exponent</td><td id="exponent"></td></tr>

--- a/static/certsplainer.js
+++ b/static/certsplainer.js
@@ -101,9 +101,10 @@ function clearFields() {
     ]) {
         setField(id, '');
     }
-    document.getElementById('curveRow').classList.remove('hidden');
-    document.getElementById('keySizeRow').classList.remove('hidden');
-    document.getElementById('exponentRow').classList.remove('hidden');
+
+    for (let id of ['curveRow', 'keySizeRow', 'exponentRow']) {
+	document.getElementById(id).classList.remove('hidden');
+    }
 }
 
 function clearTable(name) {

--- a/static/certsplainer.js
+++ b/static/certsplainer.js
@@ -200,9 +200,8 @@ function setFieldsFromJSON(properties) {
     setField('sha256hash', properties.hashes.sha256.toLowerCase());
     setField('sha256_subject_spki', properties.hashes.sha256_subject_spki.toLowerCase());
     setField('pin-sha256', properties.hashes['pin-sha256'].toLowerCase());
+    setField('id', permanentLink(properties.id, properties.id));
     setField('certificate', "-----BEGIN CERTIFICATE-----\n" + properties.Raw.replace(/(\S{64}(?!$))/g, "$1\n") + "\n-----END CERTIFICATE-----" );
-
-    setFieldRaw('id', '<a href="/api/v1/certificate?id=' + properties.id + '">' + properties.id + '</a>');
 
     let extensionsTable = document.getElementById('extensions');
     Object.keys(properties.x509v3Extensions).forEach((extensionName) => {
@@ -273,7 +272,13 @@ function setFieldsFromJSON(properties) {
         document.getElementById('trusttable').style.display = 'none';
     }
 
-    setFieldRaw('permalink', 'Displaying information for CN=' + properties.subject.cn + ' [<a href="/static/certsplainer.html?id=' + properties.id + '">permanent link</a>]');
+    let permalink = permanentLink(properties.id, 'permanent link');
+    let permatext = document.createElement(null);
+    permatext.appendChild(document.createTextNode('Displaying information for CN=' + properties.subject.cn + ' ['));
+    permatext.appendChild(permalink);
+    permatext.appendChild(document.createTextNode(']'));
+
+    setField('permalink',  permatext);
     setField('title', 'certsplained ' + properties.subject.cn);
 	window.history.replaceState({}, "", [location.protocol, '//', location.host, location.pathname].join('') + '?id=' + properties.id);
 }

--- a/static/certsplainer.js
+++ b/static/certsplainer.js
@@ -109,10 +109,6 @@ function setField(field, value) {
     }
 }
 
-function setFieldRaw(field, value) {
-    document.getElementById(field).innerHTML = value;
-}
-
 function clearFields() {
     for (let id of ['version', 'serialNumber', 'issuer', 'notBefore', 'notAfter',
         'subject', 'signatureAlgorithm', 'keySize', 'exponent', 'curve',

--- a/static/certsplainer.js
+++ b/static/certsplainer.js
@@ -135,7 +135,10 @@ function clearTable(name) {
 }
 
 function formatHTMLCommonName(name, id) {
-    return '<a href="/static/certsplainer.html?id=' + id + '">' + formatCommonName(name) + '</a>';
+    let link = document.createElement('a');
+    link.setAttribute('href', "/static/certsplainer.html?id=" + id);
+    link.textContent = formatCommonName(name);
+    return link;
 }
 
 function formatCommonName(name) {
@@ -175,8 +178,10 @@ function setFieldsFromJSON(properties) {
     }
     setField('version', properties.version);
     setField('serialNumber', properties.serialNumber.toLowerCase());
+    setField('issuer', formatHTMLCommonName(properties.issuer, properties.issuer.id));
     setField('notBefore', properties.validity.notBefore);
     setField('notAfter', properties.validity.notAfter);
+    setField('subject', formatHTMLCommonName(properties.subject, properties.id));
     setField('signatureAlgorithm', properties.signatureAlgorithm);
     if (properties.key.alg === 'RSA') {
         setField('keySize', properties.key.size);
@@ -194,8 +199,6 @@ function setFieldsFromJSON(properties) {
     setField('certificate', "-----BEGIN CERTIFICATE-----\n" + properties.Raw.replace(/(\S{64}(?!$))/g, "$1\n") + "\n-----END CERTIFICATE-----" );
 
     setFieldRaw('id', '<a href="/api/v1/certificate?id=' + properties.id + '">' + properties.id + '</a>');
-    setFieldRaw('issuer',  formatHTMLCommonName(properties.issuer, properties.issuer.id));
-    setFieldRaw('subject', formatHTMLCommonName(properties.subject, properties.id));
 
     let extensionsTable = document.getElementById('extensions');
     Object.keys(properties.x509v3Extensions).forEach((extensionName) => {

--- a/static/certsplainer.js
+++ b/static/certsplainer.js
@@ -134,11 +134,15 @@ function clearTable(name) {
     }
 }
 
-function formatHTMLCommonName(name, id) {
+function permanentLink(id, text) {
     let link = document.createElement('a');
     link.setAttribute('href', "/static/certsplainer.html?id=" + id);
-    link.textContent = formatCommonName(name);
+    link.textContent = text;
     return link;
+}
+
+function formatHTMLCommonName(name, id) {
+    return permanentLink(id, formatCommonName(name));
 }
 
 function formatCommonName(name) {

--- a/static/certsplainer.js
+++ b/static/certsplainer.js
@@ -90,7 +90,23 @@ function postCertificate(certificate) {
 }
 
 function setField(field, value) {
-    document.getElementById(field).textContent = value;
+    let node = document.getElementById(field);
+
+    switch (typeof value) {
+    case 'string':
+	// Setting textContent removes all child nodes
+	node.textContent = value;
+	break;
+
+    case 'object':
+	let newNode = node.cloneNode(false);
+	newNode.addChild(value);
+	node.parentNode.replaceChild(newNode, node);
+	break;
+
+    default:
+	console.log("setField(): Unexpected type '" + typeof(value) + "'");
+    }
 }
 
 function setFieldRaw(field, value) {

--- a/static/certsplainer.js
+++ b/static/certsplainer.js
@@ -90,6 +90,10 @@ function postCertificate(certificate) {
 }
 
 function setField(field, value) {
+    document.getElementById(field).textContent = value;
+}
+
+function setFieldRaw(field, value) {
     document.getElementById(field).innerHTML = value;
 }
 
@@ -155,10 +159,8 @@ function setFieldsFromJSON(properties) {
     }
     setField('version', properties.version);
     setField('serialNumber', properties.serialNumber.toLowerCase());
-    setField('issuer', formatHTMLCommonName(properties.issuer, properties.issuer.id));
     setField('notBefore', properties.validity.notBefore);
     setField('notAfter', properties.validity.notAfter);
-    setField('subject', formatHTMLCommonName(properties.subject, properties.id));
     setField('signatureAlgorithm', properties.signatureAlgorithm);
     if (properties.key.alg === 'RSA') {
         setField('keySize', properties.key.size);
@@ -173,8 +175,11 @@ function setFieldsFromJSON(properties) {
     setField('sha256hash', properties.hashes.sha256.toLowerCase());
     setField('sha256_subject_spki', properties.hashes.sha256_subject_spki.toLowerCase());
     setField('pin-sha256', properties.hashes['pin-sha256'].toLowerCase());
-    setField('id', '<a href="/api/v1/certificate?id=' + properties.id + '">' + properties.id + '</a>');
     setField('certificate', "-----BEGIN CERTIFICATE-----\n" + properties.Raw.replace(/(\S{64}(?!$))/g, "$1\n") + "\n-----END CERTIFICATE-----" );
+
+    setFieldRaw('id', '<a href="/api/v1/certificate?id=' + properties.id + '">' + properties.id + '</a>');
+    setFieldRaw('issuer',  formatHTMLCommonName(properties.issuer, properties.issuer.id));
+    setFieldRaw('subject', formatHTMLCommonName(properties.subject, properties.id));
 
     let extensionsTable = document.getElementById('extensions');
     Object.keys(properties.x509v3Extensions).forEach((extensionName) => {
@@ -245,7 +250,7 @@ function setFieldsFromJSON(properties) {
         document.getElementById('trusttable').style.display = 'none';
     }
 
-    setField('permalink', 'Displaying information for CN=' + properties.subject.cn + ' [<a href="/static/certsplainer.html?id=' + properties.id + '">permanent link</a>]');
+    setFieldRaw('permalink', 'Displaying information for CN=' + properties.subject.cn + ' [<a href="/static/certsplainer.html?id=' + properties.id + '">permanent link</a>]');
     setField('title', 'certsplained ' + properties.subject.cn);
 	window.history.replaceState({}, "", [location.protocol, '//', location.host, location.pathname].join('') + '?id=' + properties.id);
 }


### PR DESCRIPTION
- [x] Removes some minor repetition.
- [x] Fixes minor HTML syntax issues.
- [x] Replaces HTML constructed with raw strings with DOM manipulation.
      This fixes a few XSS issues (that were mitigated by the CSP anyway); it also ought to be faster (`innerHTML` causes the text to be reparsed), but that doesn't really matter here.