### PR TITLE
Remove miracle service from runner config

### DIFF
--- a/conf/runner.yaml
+++ b/conf/runner.yaml
@@ -67,9 +67,6 @@ runs:
         - sql.telemetry.mozilla.org
         - pipeline-dwl.prod.mozaws.net
 
-        # Miracle (Context Graph collection endpoint)
-        - miracle.services.mozilla.com
-
         # Misc
         - services.mozilla.com
         - status.services.mozilla.com
@@ -155,22 +152,19 @@ runs:
         - blocklists.settings.services.mozilla.com
         - firefox.settings.services.mozilla.com
         - webextensions.settings.services.mozilla.com
-        
+
         # Test Pilot
         - testpilot.firefox.com
         - embedly-proxy.services.mozilla.com
         - universalsearch.testpilot.firefox.com
-        
-        # Miracle (Context Graph collection endpoint)
-        - miracle.services.mozilla.com
-        
+
         # Pageshot
         - pageshot.net
-        
+
         # Push
         - push.services.mozilla.com
         - updates.push.services.mozilla.com
-        
+
         # Tiles
         - tiles.cdn.mozilla.net
         - tiles.services.mozilla.com
@@ -185,7 +179,7 @@ runs:
                   - cloud-ops@mozilla.com
 
     # Cloud Services TLS monitoring, all sites that must match modern level
-    - targets:    
+    - targets:
         # TLS Observatory
         - tls-observatory.services.mozilla.com
       assertions:
@@ -197,7 +191,7 @@ runs:
           email:
               recipients:
                   - cloud-ops@mozilla.com
-                  
+
     # absearch paging
     - targets:
         - search.services.mozilla.com
@@ -363,19 +357,6 @@ runs:
         - analysis.telemetry.mozilla.org
         - sql.telemetry.mozilla.org
         - pipeline-dwl.prod.mozaws.net
-      assertions:
-        - certificate:
-            validity:
-                notafter: ">14d"
-      cron: "30 18 * * *"
-      notifications:
-          email:
-              recipients:
-                  - b64:Y2xvdWRvcHNAbW96LXN2Yy1vcHMucGFnZXJkdXR5LmNvbQo=
-
-    # Miracle (Context Graph collection endpoint)
-    - targets:
-        - miracle.services.mozilla.com
       assertions:
         - certificate:
             validity:
@@ -552,7 +533,7 @@ runs:
           email:
               recipients:
                   - cloud-ops@mozilla.com
-                  
+
     # Cloud Services product delivery CDN always shows as bad because of RC4, AWS limitation
     - targets:
         - download-sha1.cdn.mozilla.net
@@ -565,7 +546,7 @@ runs:
           email:
               recipients:
                   - cloud-ops@mozilla.com
-                  
+
     # Julien's stuff
     - targets:
         - jve.linuxwall.info


### PR DESCRIPTION
The frontend portion of the service has been decommissioned. 