### PR TITLE
Prevent infinite loops from breaks certificate paths building

### DIFF
--- a/tlsobs-api/handlers.go
+++ b/tlsobs-api/handlers.go
@@ -291,8 +291,7 @@ func PostCertificateHandler(w http.ResponseWriter, r *http.Request) {
 
 	// to insert the trust, first build the certificate paths, then insert one trust
 	// entry for each known parent of the cert
-	var genealogy []string
-	paths, err := db.GetCertPaths(&cert, genealogy)
+	paths, err := db.GetCertPaths(&cert)
 	if err != nil {
 		httpError(w, r, http.StatusInternalServerError,
 			fmt.Sprintf("Failed to retrieve chains from database: %v", err))
@@ -352,8 +351,7 @@ func PathsHandler(w http.ResponseWriter, r *http.Request) {
 			fmt.Sprintf("Could not retrieved stored certificate from database: %v", err))
 		return
 	}
-	var genealogy []string
-	paths, err := db.GetCertPaths(cert, genealogy)
+	paths, err := db.GetCertPaths(cert)
 	if err != nil {
 		httpError(w, r, http.StatusInternalServerError,
 			fmt.Sprintf("Failed to retrieve certificate paths from database: %v", err))

--- a/tlsobs-api/handlers.go
+++ b/tlsobs-api/handlers.go
@@ -291,7 +291,8 @@ func PostCertificateHandler(w http.ResponseWriter, r *http.Request) {
 
 	// to insert the trust, first build the certificate paths, then insert one trust
 	// entry for each known parent of the cert
-	paths, err := db.GetCertPaths(&cert)
+	var genealogy []string
+	paths, err := db.GetCertPaths(&cert, genealogy)
 	if err != nil {
 		httpError(w, r, http.StatusInternalServerError,
 			fmt.Sprintf("Failed to retrieve chains from database: %v", err))
@@ -351,7 +352,8 @@ func PathsHandler(w http.ResponseWriter, r *http.Request) {
 			fmt.Sprintf("Could not retrieved stored certificate from database: %v", err))
 		return
 	}
-	paths, err := db.GetCertPaths(cert)
+	var genealogy []string
+	paths, err := db.GetCertPaths(cert, genealogy)
 	if err != nil {
 		httpError(w, r, http.StatusInternalServerError,
 			fmt.Sprintf("Failed to retrieve certificate paths from database: %v", err))

--- a/tools/pullCTLogsIntoDB.go
+++ b/tools/pullCTLogsIntoDB.go
@@ -148,8 +148,7 @@ func main() {
 
 			// to insert the trust, first build the certificate paths, then insert one trust
 			// entry for each known parent of the cert
-			var genealogy []string
-			paths, err := db.GetCertPaths(&cert, genealogy)
+			paths, err := db.GetCertPaths(&cert)
 			if err != nil {
 				log.Printf("Failed to retrieve chains from database: %v", err)
 				continue

--- a/tools/pullCTLogsIntoDB.go
+++ b/tools/pullCTLogsIntoDB.go
@@ -91,6 +91,7 @@ func main() {
 				continue
 			}
 			log.Printf("CN=%s", ctcertX509.Subject.CommonName)
+			log.Printf("Issuer=%s", ctcertX509.Issuer.CommonName)
 			log.Printf("Not Before=%s", ctcertX509.NotBefore)
 			log.Printf("Not After=%s", ctcertX509.NotAfter)
 
@@ -147,7 +148,8 @@ func main() {
 
 			// to insert the trust, first build the certificate paths, then insert one trust
 			// entry for each known parent of the cert
-			paths, err := db.GetCertPaths(&cert)
+			var genealogy []string
+			paths, err := db.GetCertPaths(&cert, genealogy)
 			if err != nil {
 				log.Printf("Failed to retrieve chains from database: %v", err)
 				continue


### PR DESCRIPTION
Cross-signing in the web pki apparently contains a lot of infinite loops
that break the building of paths. This patch implement a simple []string
that contains the CNs of certs that have already been seen in the path,
to prevent the function from looping indefinitely.