### PR TITLE
Certificate insert optimizations

### DIFF
--- a/database/database.go
+++ b/database/database.go
@@ -69,7 +69,6 @@ func RegisterConnection(dbname, user, password, hostport, sslmode string) (*DB, 
 	if err != nil {
 		db = nil
 	}
-
 	return &DB{db}, err
 }
 

--- a/tlsobs-api/insert_test.go
+++ b/tlsobs-api/insert_test.go
@@ -1,0 +1,134 @@
+package main
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"log"
+	"os"
+	"testing"
+
+	"github.com/mozilla/tls-observatory/certificate"
+	"github.com/mozilla/tls-observatory/database"
+)
+
+const mozillaOrgCert = `-----BEGIN CERTIFICATE-----
+MIIHeTCCBmGgAwIBAgIQC/20CQrXteZAwwsWyVKaJzANBgkqhkiG9w0BAQsFADB1
+MQswCQYDVQQGEwJVUzEVMBMGA1UEChMMRGlnaUNlcnQgSW5jMRkwFwYDVQQLExB3
+d3cuZGlnaWNlcnQuY29tMTQwMgYDVQQDEytEaWdpQ2VydCBTSEEyIEV4dGVuZGVk
+IFZhbGlkYXRpb24gU2VydmVyIENBMB4XDTE2MDMxMDAwMDAwMFoXDTE4MDUxNzEy
+MDAwMFowgf0xHTAbBgNVBA8MFFByaXZhdGUgT3JnYW5pemF0aW9uMRMwEQYLKwYB
+BAGCNzwCAQMTAlVTMRkwFwYLKwYBBAGCNzwCAQITCERlbGF3YXJlMRAwDgYDVQQF
+Ewc1MTU3NTUwMSQwIgYDVQQJExs4OCBDb2xpbiBQIEtlbGx5LCBKciBTdHJlZXQx
+DjAMBgNVBBETBTk0MTA3MQswCQYDVQQGEwJVUzETMBEGA1UECBMKQ2FsaWZvcm5p
+YTEWMBQGA1UEBxMNU2FuIEZyYW5jaXNjbzEVMBMGA1UEChMMR2l0SHViLCBJbmMu
+MRMwEQYDVQQDEwpnaXRodWIuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIB
+CgKCAQEA54hc8pZclxgcupjiA/F/OZGRwm/ZlucoQGTNTKmBEgNsrn/mxhngWmPw
+bAvUaLP//T79Jc+1WXMpxMiz9PK6yZRRFuIo0d2bx423NA6hOL2RTtbnfs+y0PFS
+/YTpQSelTuq+Fuwts5v6aAweNyMcYD0HBybkkdosFoDccBNzJ92Ac8I5EVDUc3Or
+/4jSyZwzxu9kdmBlBzeHMvsqdH8SX9mNahXtXxRpwZnBiUjw36PgN+s9GLWGrafd
+02T0ux9Yzd5ezkMxukqEAQ7AKIIijvaWPAJbK/52XLhIy2vpGNylyni/DQD18bBP
+T+ZG1uv0QQP9LuY/joO+FKDOTler4wIDAQABo4IDejCCA3YwHwYDVR0jBBgwFoAU
+PdNQpdagre7zSmAKZdMh1Pj41g8wHQYDVR0OBBYEFIhcSGcZzKB2WS0RecO+oqyH
+IidbMCUGA1UdEQQeMByCCmdpdGh1Yi5jb22CDnd3dy5naXRodWIuY29tMA4GA1Ud
+DwEB/wQEAwIFoDAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwdQYDVR0f
+BG4wbDA0oDKgMIYuaHR0cDovL2NybDMuZGlnaWNlcnQuY29tL3NoYTItZXYtc2Vy
+dmVyLWcxLmNybDA0oDKgMIYuaHR0cDovL2NybDQuZGlnaWNlcnQuY29tL3NoYTIt
+ZXYtc2VydmVyLWcxLmNybDBLBgNVHSAERDBCMDcGCWCGSAGG/WwCATAqMCgGCCsG
+AQUFBwIBFhxodHRwczovL3d3dy5kaWdpY2VydC5jb20vQ1BTMAcGBWeBDAEBMIGI
+BggrBgEFBQcBAQR8MHowJAYIKwYBBQUHMAGGGGh0dHA6Ly9vY3NwLmRpZ2ljZXJ0
+LmNvbTBSBggrBgEFBQcwAoZGaHR0cDovL2NhY2VydHMuZGlnaWNlcnQuY29tL0Rp
+Z2lDZXJ0U0hBMkV4dGVuZGVkVmFsaWRhdGlvblNlcnZlckNBLmNydDAMBgNVHRMB
+Af8EAjAAMIIBfwYKKwYBBAHWeQIEAgSCAW8EggFrAWkAdgCkuQmQtBhYFIe7E6LM
+Z3AKPDWYBPkb37jjd80OyA3cEAAAAVNhieoeAAAEAwBHMEUCIQCHHSEY/ROK2/sO
+ljbKaNEcKWz6BxHJNPOtjSyuVnSn4QIgJ6RqvYbSX1vKLeX7vpnOfCAfS2Y8lB5R
+NMwk6us2QiAAdgBo9pj4H2SCvjqM7rkoHUz8cVFdZ5PURNEKZ6y7T0/7xAAAAVNh
+iennAAAEAwBHMEUCIQDZpd5S+3to8k7lcDeWBhiJASiYTk2rNAT26lVaM3xhWwIg
+NUqrkIODZpRg+khhp8ag65B8mu0p4JUAmkRDbiYnRvYAdwBWFAaaL9fC7NP14b1E
+sj7HRna5vJkRXMDvlJhV1onQ3QAAAVNhieqZAAAEAwBIMEYCIQDnm3WStlvE99GC
+izSx+UGtGmQk2WTokoPgo1hfiv8zIAIhAPrYeXrBgseA9jUWWoB4IvmcZtshjXso
+nT8MIG1u1zF8MA0GCSqGSIb3DQEBCwUAA4IBAQCLbNtkxuspqycq8h1EpbmAX0wM
+5DoW7hM/FVdz4LJ3Kmftyk1yd8j/PSxRrAQN2Mr/frKeK8NE1cMji32mJbBqpWtK
+/+wC+avPplBUbNpzP53cuTMF/QssxItPGNP5/OT9Aj1BxA/NofWZKh4ufV7cz3pY
+RDS4BF+EEFQ4l5GY+yp4WJA/xSvYsTHWeWxRD1/nl62/Rd9FN2NkacRVozCxRVle
+FrBHTFxqIP6kDnxiLElBrZngtY07ietaYZVLQN/ETyqLQftsf8TecwTklbjvm8NT
+JqbaIVifYwqwNN+4lRxS3F5lNlA/il12IOgbRioLI62o8G0DaEUQgHNf8vSG
+-----END CERTIFICATE-----`
+
+func BenchmarkInsertNewCertificate(b *testing.B) {
+	db, err := database.RegisterConnection(
+		"observatory",
+		os.Getenv("TLSOBS_POSTGRESUSER"),
+		os.Getenv("TLSOBS_POSTGRESPASS"),
+		os.Getenv("TLSOBS_POSTGRES"),
+		"disable")
+	if err != nil {
+		panic(err)
+	}
+	pemCert, _ := pem.Decode([]byte(mozillaOrgCert))
+	if err != nil {
+		panic(err)
+	}
+	asn1 := pemCert.Bytes
+	certs, err := x509.ParseCertificates(asn1)
+	if err != nil {
+		panic(err)
+	}
+	for i := 0; i < b.N; i++ {
+		b.StartTimer()
+		id, trustIds, err := insert(db, certs[0])
+		if err != nil {
+			panic(err)
+		}
+		b.StopTimer()
+		cleanup(db, trustIds, id)
+	}
+}
+
+func cleanup(db *database.DB, trustIds []int64, id int64) {
+	var err error
+	for _, trustID := range trustIds {
+		_, err = db.Exec(`DELETE FROM trust WHERE trust.id = $1`, trustID)
+		if err != nil {
+			fmt.Println(id, trustIds)
+			panic(err)
+		}
+	}
+
+	_, err = db.Exec(`DELETE FROM certificates WHERE certificates.id = $1`, id)
+	if err != nil {
+		fmt.Println(id, trustIds)
+		panic(err)
+	}
+}
+
+func insert(db *database.DB, certX509 *x509.Certificate) (id int64, trustIds []int64, err error) {
+	certHash := certificate.SHA256Hash(certX509.Raw)
+	var valInfo certificate.ValidationInfo
+	cert := certificate.CertToStored(certX509, certHash, "", "", "", &valInfo)
+	id, err = db.InsertCertificate(&cert)
+	if err != nil {
+		log.Printf("Failed to store certificate in database: %v\n", err)
+		return
+	}
+	cert.ID = id
+	if cert.IsSelfSigned() {
+		log.Print("Certificate is self-signed")
+		return
+	}
+	paths, err := db.GetCertPaths(&cert)
+	if err != nil {
+		log.Printf("Failed to retrieve chains from database: %v\n", err)
+		return
+	}
+	for _, parent := range paths.Parents {
+		cert.ValidationInfo = parent.GetValidityMap()
+		trustID, err := db.InsertTrustToDB(cert, cert.ID, parent.Cert.ID)
+		if err != nil {
+			log.Printf("Failed to store trust in database: %v\n", err)
+			return id, trustIds, err
+		}
+		trustIds = append(trustIds, trustID)
+	}
+	return
+}


### PR DESCRIPTION
```
Before the optimization: BenchmarkInsertNewCertificate-8   	     100	  16625509 ns/op
After the optimization:  BenchmarkInsertNewCertificate-8   	     100	  11918866 ns/op
```

So ~30% faster now.

There's still plenty to optimize, as there's another N+1 problem with the truststore validation checks. My guess is that will also add another 30% speed improvement.