### PR TITLE
Added slack webhook notification option

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,10 @@ It requires Golang 1.7+ to be installed:
 ```bash
 $ go version
 go version go1.7 linux/amd64
- 
+
 $ export GOPATH="$HOME/go"
 $ mkdir $GOPATH
- 
+
 $ export PATH=$GOPATH/bin:$PATH
 ```
 Then get the binary:
@@ -124,7 +124,7 @@ to build all components.
 ```bash
 $ docker run -it golang:1.7
 
-root@c63f11b8852b:/go# go get github.com/mozilla/tls-observatory 
+root@c63f11b8852b:/go# go get github.com/mozilla/tls-observatory
 package github.com/mozilla/tls-observatory: no buildable Go source files in /go/src/github.com/mozilla/tls-observatory
 
 root@c63f11b8852b:/go# cd $GOPATH/src/github.com/mozilla/tls-observatory
@@ -147,7 +147,7 @@ CREATE DATABASE
 postgres=# \c observatory
 You are now connected to database "observatory" as user "postgres".
 
-postgres=# \i /go/src/github.com/mozilla/tls-observatory/database/schema.sql 
+postgres=# \i /go/src/github.com/mozilla/tls-observatory/database/schema.sql
 ```
 This automatically creates all tables, indexes, users and grants to work
 with the default configuration.
@@ -205,6 +205,9 @@ parameters can also be provided through environment variables:
 * `TLSOBS_RUNNER_SMTP_FROM` is the from address of email notifications sent by the runner (eg. `mynotification@tlsobservatory.example.net`)
 * `TLSOBS_RUNNER_SMTP_AUTH_USER` is the smtp authenticated username (eg `tlsobsrunner`)
 * `TLSOBS_RUNNER_SMTP_AUTH_PASS` is the smtp user password (eg. `mysecretpassphrase`)
+* `TLSOBS_RUNNER_SLACK_WEBHOOK` is the slack webhook (eg. `https://hooks.slack.com/services/not/a/realwebhook`)
+* `TLSOBS_RUNNER_SLACK_USERNAME` is the what the message sender's username will be (eg. `tlsbot`)
+* `TLSOBS_RUNNER_SLACK_ICONEMOJI` is the what the message sender's icon will be (eg. `:telescope:`)
 
 ## API Endpoints
 
@@ -281,7 +284,7 @@ curl -X POST -F certificate=@example.pem https://tls-observatory.services.mozill
 
 **Output**: a `json` document containing the parsed certificate and its raw X509 version encoded with base64.
 
-**Caching**: Certificates are only stored once. The database uses the SHA256 hash of the DER (binary) certificate to identify duplicates. Posting a certificate already stored in database returns the stored version. 
+**Caching**: Certificates are only stored once. The database uses the SHA256 hash of the DER (binary) certificate to identify duplicates. Posting a certificate already stored in database returns the stored version.
 
 ### GET /api/v1/paths
 
@@ -310,7 +313,7 @@ curl https://tls-observatory.services.mozilla.com/api/v1/truststore?store=mozill
 **Parameters**:
 
 * `store` is the store to retrieve certificates from. "mozilla", "android", "apple", "microsoft" and "ubuntu" are allowed.
-* `format`, either "pem" or "json". 
+* `format`, either "pem" or "json".
 
 **Output**: if `format` is pem, a series of PEM-format certificates. If `format` is json, a json array of certificate objects, each with the same format of `/api/v1/certificate`.
 
@@ -538,7 +541,7 @@ WHERE has_tls=true
 GROUP BY has_tls, output->>'level'
 ORDER BY COUNT(DISTINCT(target)) DESC;
 
- count |     Mozilla Configuration      
+ count |     Mozilla Configuration
 -------+--------------------------------
   1302 | intermediate
    699 | bad

--- a/conf/runner.yaml
+++ b/conf/runner.yaml
@@ -690,6 +690,8 @@ smtp:
     #    pass: somepass
 
 slack:
+    # slackbot will send the notification to each run's specified channels
+    # slackbot's username and icon can be customized below or left empty for slack's default
     username: tls-observatory
-    icon_emoji: ':telescope:'
+    iconemoji: ':telescope:'
     # webhook: https://hooks.slack.com/services/not/a/realwebhook

--- a/conf/runner.yaml
+++ b/conf/runner.yaml
@@ -691,3 +691,8 @@ smtp:
     #auth:
     #    user: someuser
     #    pass: somepass
+
+slack:
+    username: tls-observatory
+    icon_emoji: ':telescope:'
+    # webhook: https://hooks.slack.com/services/not/a/realwebhook

--- a/tlsobs-runner/main.go
+++ b/tlsobs-runner/main.go
@@ -36,7 +36,13 @@ type Configuration struct {
 			User, Pass string
 		}
 	}
+	Slack struct {
+		Username string
+		Icon_emoji string
+		Webhook string
+	}
 }
+
 type Run struct {
 	Targets       []string
 	Assertions    []Assertion
@@ -63,6 +69,9 @@ type NotificationsConf struct {
 	}
 	Email struct {
 		Recipients []string
+	}
+	Slack struct {
+		Channels []string
 	}
 }
 
@@ -276,6 +285,15 @@ func getConf(cfg string) (c Configuration) {
 	}
 	if os.Getenv("TLSOBS_RUNNER_SMTP_AUTH_PASS") != "" {
 		c.Smtp.Auth.Pass = os.Getenv("TLSOBS_RUNNER_SMTP_AUTH_PASS")
+	}
+	if os.Getenv("TLSOBS_RUNNER_SLACK_USERNAME") != "" {
+		c.Slack.Username = os.Getenv("TLSOBS_RUNNER_USERNAME")
+	}
+	if os.Getenv("TLSOBS_RUNNER_SLACK_ICON") != "" {
+		c.Slack.Icon_emoji = os.Getenv("TLSOBS_RUNNER_SLACK_ICON")
+	}
+	if os.Getenv("TLSOBS_RUNNER_SLACK_WEBHOOK") != "" {
+		c.Slack.Webhook = os.Getenv("TLSOBS_RUNNER_SLACK_WEBHOOK")
 	}
 	return c
 }

--- a/tlsobs-runner/main.go
+++ b/tlsobs-runner/main.go
@@ -37,9 +37,7 @@ type Configuration struct {
 		}
 	}
 	Slack struct {
-		Username string
-		Icon_emoji string
-		Webhook string
+		Username, IconEmoji, Webhook string
 	}
 }
 
@@ -289,8 +287,8 @@ func getConf(cfg string) (c Configuration) {
 	if os.Getenv("TLSOBS_RUNNER_SLACK_USERNAME") != "" {
 		c.Slack.Username = os.Getenv("TLSOBS_RUNNER_USERNAME")
 	}
-	if os.Getenv("TLSOBS_RUNNER_SLACK_ICON") != "" {
-		c.Slack.Icon_emoji = os.Getenv("TLSOBS_RUNNER_SLACK_ICON")
+	if os.Getenv("TLSOBS_RUNNER_SLACK_ICONEMOJI") != "" {
+		c.Slack.IconEmoji = os.Getenv("TLSOBS_RUNNER_SLACK_ICONEMOJI")
 	}
 	if os.Getenv("TLSOBS_RUNNER_SLACK_WEBHOOK") != "" {
 		c.Slack.Webhook = os.Getenv("TLSOBS_RUNNER_SLACK_WEBHOOK")

--- a/tlsobs-runner/main_test.go
+++ b/tlsobs-runner/main_test.go
@@ -40,7 +40,7 @@ smtp:
 
 slack:
     username: 'tls-observatory'
-    icon_emoji: ':telescope:'
+    iconemoji: ':telescope:'
     webhook: https://hooks.slack.com/services/not/a/realwebhook
 `
 	// override smtp user & pass using env variables
@@ -127,8 +127,8 @@ slack:
 	if conf.Slack.Username != "tls-observatory" {
 		t.Fatalf("invalid slack username, expected 'tls-observatory', got %q", conf.Slack.Username)
 	}
-	if conf.Slack.Icon_emoji != ":telescope:" {
-		t.Fatalf("invalid slack icon, expected ':telescope:', got %q", conf.Slack.Icon_emoji)
+	if conf.Slack.IconEmoji != ":telescope:" {
+		t.Fatalf("invalid slack icon, expected ':telescope:', got %q", conf.Slack.IconEmoji)
 	}
 	if conf.Slack.Webhook != "secrethook" {
 		t.Fatalf("invalid slack webhook, expected 'secrethook', got %q", conf.Slack.Webhook)

--- a/tlsobs-runner/notifications.go
+++ b/tlsobs-runner/notifications.go
@@ -6,8 +6,11 @@
 package main
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"log"
+	"net/http"
 	"net/smtp"
 	"time"
 )
@@ -21,6 +24,7 @@ type Notification struct {
 func processNotifications(notifchan chan Notification, done chan bool) {
 	emailntfs := make(map[string][]byte)
 	ircntfs := make(map[string][]byte)
+	slackntfs := make(map[string][]byte)
 	for n := range notifchan {
 		log.Printf("[info] received notification for target %q with body: %s", n.Target, n.Body)
 		for _, rcpt := range n.Conf.Email.Recipients {
@@ -37,11 +41,26 @@ func processNotifications(notifchan chan Notification, done chan bool) {
 			}
 			ircntfs[rcpt] = []byte(fmt.Sprintf("%s\n%s: %s", body, n.Target, n.Body))
 		}
+		for _, rcpt := range n.Conf.Slack.Channels {
+			var body []byte
+			if _, ok := slackntfs[rcpt]; ok {
+				body = slackntfs[rcpt]
+			}
+			slackntfs[rcpt] = []byte(fmt.Sprintf("%s\n%s: %s", body, n.Target, n.Body))
+			log.Println(fmt.Sprintf("huh?: %s", slackntfs[rcpt]))
+		}
 	}
 	for rcpt, body := range emailntfs {
 		err := sendMail(rcpt, body)
 		if err != nil {
 			log.Printf("[error] failed to send email notification to %q: %v", rcpt, err)
+		}
+	}
+	for rcpt, body := range slackntfs {
+		log.Println(fmt.Sprintf("huh2?: %s", body))
+		err := sendSlackMessage(rcpt, body)
+		if err != nil {
+			log.Printf("[error] failed to send slack notification to %q: %v", rcpt, err)
 		}
 	}
 	done <- true
@@ -67,5 +86,21 @@ Date: %s
 
 %s`, conf.Smtp.From, rcpt, time.Now().Format("Mon, 2 Jan 2006 15:04:05 -0700"), body)),
 	)
+	return
+}
+
+func sendSlackMessage(rcpt string, body []byte) (err error) {
+	debugprint("Publishing notification to slack channel %q", rcpt)
+	raw := map[string]string{
+		"channel":    rcpt,
+		"text":       fmt.Sprintf("%s", body),
+		"username":   conf.Slack.Username,
+		"icon_emoji": conf.Slack.Icon_emoji,
+	}
+	payload, err := json.Marshal(&raw)
+	if err != nil {
+		return
+	}
+	_, err = http.Post(conf.Slack.Webhook, "application/json", bytes.NewReader(payload))
 	return
 }

--- a/tlsobs-runner/notifications.go
+++ b/tlsobs-runner/notifications.go
@@ -47,7 +47,6 @@ func processNotifications(notifchan chan Notification, done chan bool) {
 				body = slackntfs[rcpt]
 			}
 			slackntfs[rcpt] = []byte(fmt.Sprintf("%s\n%s: %s", body, n.Target, n.Body))
-			log.Println(fmt.Sprintf("huh?: %s", slackntfs[rcpt]))
 		}
 	}
 	for rcpt, body := range emailntfs {
@@ -57,10 +56,9 @@ func processNotifications(notifchan chan Notification, done chan bool) {
 		}
 	}
 	for rcpt, body := range slackntfs {
-		log.Println(fmt.Sprintf("huh2?: %s", body))
 		err := sendSlackMessage(rcpt, body)
 		if err != nil {
-			log.Printf("[error] failed to send slack notification to %q: %v", rcpt, err)
+			log.Printf("[error] failed to send slack notification to channel %q: %v", rcpt, err)
 		}
 	}
 	done <- true
@@ -95,7 +93,7 @@ func sendSlackMessage(rcpt string, body []byte) (err error) {
 		"channel":    rcpt,
 		"text":       fmt.Sprintf("%s", body),
 		"username":   conf.Slack.Username,
-		"icon_emoji": conf.Slack.Icon_emoji,
+		"icon_emoji": conf.Slack.IconEmoji,
 	}
 	payload, err := json.Marshal(&raw)
 	if err != nil {


### PR DESCRIPTION
This commit adds the option of sending a slack message via webhook when a notification needs to be sent.

Included:
* sample config in `conf/runner.yaml`. Each run can have multiple channels to send notifications to, but each config file (and therefore each runner) only supports one username, one icon, and one webhook. 
* parsing slack config in `tlsobs-runner/main.go`, as well as the ability to override slack config with environment variables
* post request logic in `tlsobs-runner/notifications.go`
* environment override logic tests in `tlsobs-runner/main_test.go`