### PR TITLE
Make several things configurable through env vars

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -21,6 +21,7 @@ type Config struct {
 		MaxProc         int
 		Timeout         time.Duration
 		APIListenAddr   string
+		StaticAssetPath string
 	}
 	TrustStores struct {
 		UbuntuTS    string
@@ -55,6 +56,28 @@ func Load(path string) (conf Config, err error) {
 	}
 	if apiListenAddr := os.Getenv("TLSOBS_APILISTENADDR"); apiListenAddr != "" {
 		conf.General.APIListenAddr = apiListenAddr
+	}
+	if cipherscanPath := os.Getenv("TLSOBS_CIPHERSCANPATH"); cipherscanPath != "" {
+		conf.General.CipherscanPath = cipherscanPath
+	}
+	if ubuntuTSPath := os.Getenv("TLSOBS_UBUNTUTSPATH"); ubuntuTSPath != "" {
+		conf.TrustStores.UbuntuTS = ubuntuTSPath
+	}
+	if mozillaTSPath := os.Getenv("TLSOBS_MOZILLATSPATH"); mozillaTSPath != "" {
+		conf.TrustStores.MozillaTS = mozillaTSPath
+	}
+	if microsoftTSPath := os.Getenv("TLSOBS_MICROSOFTTSPATH"); microsoftTSPath != "" {
+		conf.TrustStores.MicrosoftTS = microsoftTSPath
+	}
+	if appleTSPath := os.Getenv("TLSOBS_APPLETSPATH"); appleTSPath != "" {
+		conf.TrustStores.AppleTS = appleTSPath
+	}
+	if androidTSPath := os.Getenv("TLSOBS_ANDROIDTSPATH"); androidTSPath != "" {
+		conf.TrustStores.AndroidTS = androidTSPath
+	}
+	conf.General.StaticAssetPath = "./static/"
+	if staticAssetPath := os.Getenv("TLSOBS_STATICASSETPATH"); staticAssetPath != "" {
+		conf.General.StaticAssetPath = staticAssetPath
 	}
 	return
 }

--- a/tlsobs-api/main.go
+++ b/tlsobs-api/main.go
@@ -22,8 +22,6 @@ func init() {
 
 func main() {
 
-	router := NewRouter()
-
 	var cfgFile string
 	var debug bool
 	flag.StringVar(&cfgFile, "c", "/etc/tls-observatory/api.cfg", "Input file csv format")
@@ -38,6 +36,7 @@ func main() {
 	if err != nil {
 		log.Fatal("Failed to load configuration: %v", err)
 	}
+	router := NewRouter(conf)
 	if !conf.General.Enable && os.Getenv("TLSOBS_API_ENABLE") != "on" {
 		log.Fatal("API is disabled in configuration")
 	}

--- a/tlsobs-api/router.go
+++ b/tlsobs-api/router.go
@@ -4,12 +4,13 @@ import (
 	"net/http"
 
 	"github.com/gorilla/mux"
+	"github.com/mozilla/tls-observatory/config"
 )
 
-func NewRouter() *mux.Router {
-
+func NewRouter(conf config.Config) *mux.Router {
 	router := mux.NewRouter().StrictSlash(true)
-	router.PathPrefix("/static/").Handler(http.StripPrefix("/static/", http.FileServer(http.Dir("./static/"))))
+	router.PathPrefix("/static/").Handler(http.StripPrefix("/static/", http.FileServer(
+		http.Dir(conf.General.StaticAssetPath))))
 	for _, route := range routes {
 		var handler http.Handler
 

--- a/worker/evCheckerWorker/config.go
+++ b/worker/evCheckerWorker/config.go
@@ -1,4 +1,4 @@
 package evCheckerWorker
 
-// The path to the ev-checker binary the worker should use
-const EvCheckerBinaryName = "ev-checker"
+// EvCheckerBinaryName is the path to the ev-checker binary the worker should use
+var EvCheckerBinaryName = "ev-checker"

--- a/worker/evCheckerWorker/evCheckerWorker.go
+++ b/worker/evCheckerWorker/evCheckerWorker.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"os"
 	"os/exec"
 
 	"encoding/base64"
@@ -19,6 +20,9 @@ var workerDesc = `Determines if a given EV policy fulfills the requirements of M
 var log = logger.GetLogger()
 
 func init() {
+	if path := os.Getenv("TLSOBS_EVCHECKERPATH"); path != "" {
+		EvCheckerBinaryName = path
+	}
 	_, err := exec.LookPath(EvCheckerBinaryName)
 	if err != nil {
 		log.Warn("Could not find ev-checker binary, " + workerName + " disabled.")

--- a/worker/top1m/top1m.go
+++ b/worker/top1m/top1m.go
@@ -43,7 +43,11 @@ type certificateRank struct {
 func init() {
 	runner := new(ranker)
 	runner.Ranks = make(map[string]int64)
-	fd, err := os.Open("/etc/tls-observatory/top-1m.csv")
+	top1mPath := "/etc/tls-observatory/top-1m.csv"
+	if path := os.Getenv("TLSOBS_TOP1MPATH"); path != "" {
+		top1mPath = path
+	}
+	fd, err := os.Open(top1mPath)
 	if err != nil {
 		log.Printf("Failed to initialize %s: %v", workerName, err)
 		return


### PR DESCRIPTION
- top-1m.csv
- truststore location
- cipherscan location
- static asset location
- ev-checker location

top1m and ev-checker config can't be in config.go because there's currently no way to pass any configuration to workers.