### PR TITLE
Add data.mozilla.com to runner config

### DIFF
--- a/conf/runner.yaml
+++ b/conf/runner.yaml
@@ -102,6 +102,7 @@ runs:
         - schemas.telemetry.mozilla.org
         - telemetry.mozilla.org
         - data-presto.data.mozaws.net
+        - data.mozilla.com
 
         # Misc
         - services.mozilla.com
@@ -428,6 +429,7 @@ runs:
         - schemas.telemetry.mozilla.org
         - telemetry.mozilla.org
         - data-presto.data.mozaws.net
+        - data.mozilla.com
       assertions:
         - certificate:
             validity:


### PR DESCRIPTION
This is a deprecated endpoint but is still being used by old clients.