### PR TITLE
Dockerfile: copy binaries instead of moving them

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,11 +14,11 @@ RUN go install github.com/mozilla/tls-observatory/tlsobs-api && \
     rm -rf ev-checker
 RUN addgroup -gid 10001 app && \
     adduser --home /app --gecos "" --ingroup=app --uid=10001 --disabled-login app
-RUN mv $GOPATH/bin/tlsobs-api /app/ && \
-    mv $GOPATH/bin/tlsobs-scanner /app/ && \
-    mv $GOPATH/bin/tlsobs-runner /app/ && \
-    mv $GOPATH/bin/ev-checker /app/
-RUN mv $GOPATH/src/github.com/mozilla/tls-observatory/version.json /app
+RUN cp $GOPATH/bin/tlsobs-api /app/ && \
+    cp $GOPATH/bin/tlsobs-scanner /app/ && \
+    cp $GOPATH/bin/tlsobs-runner /app/ && \
+    cp $GOPATH/bin/ev-checker /app/
+RUN cp $GOPATH/src/github.com/mozilla/tls-observatory/version.json /app
 RUN ln -s $GOPATH/src/github.com/mozilla/tls-observatory/conf /etc/tls-observatory
 RUN ln -s $GOPATH/src/github.com/mozilla/tls-observatory/cipherscan /opt/cipherscan
 


### PR DESCRIPTION
Moving the binaries broke some people's workflows, e.g. #248. Copying will restore backwards-compatibility.