### PR TITLE
Add Kubernetes deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN go install github.com/mozilla/tls-observatory/tlsobs-api && \
     go install github.com/mozilla/tls-observatory/tlsobs-scanner && \
     go install github.com/mozilla/tls-observatory/tlsobs-runner && \
     apt-get update -y && \
-    apt-get install git libcurl4-nss-dev libnss3 libnss3-dev clang -y && \
+    apt-get install git libcurl4-nss-dev libnss3 libnss3-dev clang postgresql-client -y && \
     git clone https://github.com/mozkeeler/ev-checker.git && \
     cd ev-checker && \
     make && \

--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ $ docker run -it mozilla/tls-observatory tlsobs accounts.firefox.com
 
 ## Developing
 
+You can use the Kubernetes configuration provided in https://github.com/mozilla/tls-observatory/tree/master/kubernetes , or alternatively, you can do the following:
+
 You can use the `mozilla/tls-observatory` docker container for development:
 ```bash
 $ docker pull mozilla/tls-observatory

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -1,0 +1,17 @@
+WARNING: It's possible for these files to become out of date, as we don't expect contributors to check these files still work with the changes they make to the code.
+
+# Running with Kubernetes
+
+You can run the TLS Observatory API and Scanner, in addition to PostgreSQL, in a Kubernetes cluster. For example, you might want to use [minikube](https://github.com/kubernetes/minikube) to run a Kubernetes cluster locally in which you can run everything you need to run TLS Observatory.
+
+This configuration uses the mozilla/tls-observatory image. By default, Kubernetes will pull this image from Dockerhub.
+
+Ensure `kubectl` is correctly configured and has access to your cluster, and then run `kubectl apply -f deployment.yaml` in order to create the PostgreSQL database, the API, and the scanner. The database will be uninitialized, so once the PostgreSQL container is running (check the status with `kubectl get po`), you can run the setup_db job with `kubectl apply -f setup_db.yaml` to initialize the database. After the job is finished, the api and scanner containers should successfully start and be ready for connections. You can then get the URL for the API with `kubectl describe svc api`. If you're using `minikube`, you need to instead run `minikube service api --url`. For example:
+
+```
+❯ minikube service api --url     
+http://192.168.64.6:30647
+
+❯ tlsobs -observatory http://192.168.64.6:30647 -r mozilla.com 
+# output omitted
+```

--- a/kubernetes/deployment.yaml
+++ b/kubernetes/deployment.yaml
@@ -1,0 +1,103 @@
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: postgres
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: postgres
+    spec:
+      containers:
+      - name: postgres
+        image: postgres
+        env:
+          - name: POSTGRES_PASSWORD
+            value: password
+        ports:
+        - containerPort: 5432
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+spec:
+  type: NodePort
+  ports:
+  - port: 5432
+    protocol: TCP
+  selector:
+    app: postgres
+
+---
+
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: api
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: api
+    spec:
+      containers:
+      - name: api
+        image: mozilla/tls-observatory
+        imagePullPolicy: IfNotPresent
+        command:
+          - /app/tlsobs-api
+        env:
+          - name: TLSOBS_POSTGRES
+            value: postgres
+          - name: TLSOBS_POSTGRESUSER
+            value: tlsobsapi
+          - name: TLSOBS_POSTGRESPASS
+            value: mysecretpassphrase
+        ports:
+        - containerPort: 8083
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: api
+spec:
+  type: NodePort
+  ports:
+  - port: 8083
+    protocol: TCP
+  selector:
+    app: api
+
+---
+
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: scanner
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: scanner
+    spec:
+      containers:
+      - name: scanner
+        image: mozilla/tls-observatory
+        imagePullPolicy: IfNotPresent
+        command:
+          - /app/tlsobs-scanner
+        env:
+          - name: TLSOBS_POSTGRES
+            value: postgres
+          - name: TLSOBS_POSTGRESUSER
+            value: tlsobsscanner
+          - name: TLSOBS_POSTGRESPASS
+            value: mysecretpassphrase

--- a/kubernetes/setup_db.yaml
+++ b/kubernetes/setup_db.yaml
@@ -1,0 +1,22 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: setup-db
+spec:
+  template:
+    metadata:
+      name: setup-db
+    spec:
+      containers:
+      - name: setup-db
+        image: mozilla/tls-observatory
+        imagePullPolicy: IfNotPresent
+        command: ["bash", "-c", "echo 'CREATE DATABASE observatory;' | psql && psql observatory < /go/src/github.com/mozilla/tls-observatory/database/schema.sql"]
+        env:
+        - name: PGHOST
+          value: postgres
+        - name: PGUSER
+          value: postgres
+        - name: PGPASSWORD
+          value: password
+      restartPolicy: Never


### PR DESCRIPTION
This adds a simple Kubernetes configuration that runs postgres, the api and the scanner I used a few days ago to try to reproduce a bug.

 I don't know if we prefer docker-compose (#171) over kubernetes.