### PR TITLE
Add exception for RSA CHACHA20 cipher to fix cloudflare sites with RSA certs being marked as insecure

### DIFF
--- a/worker/mozillaEvaluationWorker/mozillaEvaluationWorker.go
+++ b/worker/mozillaEvaluationWorker/mozillaEvaluationWorker.go
@@ -673,7 +673,7 @@ func contains(slice []string, entry string) bool {
 func extra(s1, s2 []string) (extra []string) {
 	for _, e := range s2 {
 		// FIXME: https://github.com/mozilla/tls-observatory/issues/186
-		if e == "ECDHE-ECDSA-CHACHA20-POLY1305-OLD" {
+		if e == "ECDHE-ECDSA-CHACHA20-POLY1305-OLD" || e == "ECDHE-RSA-CHACHA20-POLY1305-OLD" {
 			continue
 		}
 		if !contains(s1, e) {


### PR DESCRIPTION
Add the ECDHE-RSA-CHACHA20-POLY1305-OLD cipher to the ignored ciphers added for #186 as this is also used by cloudflare on sites that have a RSA certificate as noted in #226