### PR TITLE
Timeout cipherscan after 3 minutes

### DIFF
--- a/conf/scanner.cfg
+++ b/conf/scanner.cfg
@@ -5,7 +5,7 @@ Enable        = on
 
 # how many parallel processes are allowed to run. A good number is
 # to set this to 10*cores, because the scanner is mostly IO bound.
-MaxProc       = 40
+MaxProc       = 60
 
 # if no new scan is received after X number of minutes, shut down
 Timeout       = 10

--- a/connection/retriever.go
+++ b/connection/retriever.go
@@ -8,6 +8,7 @@ import (
 	"math/rand"
 	"net"
 	"os/exec"
+	"time"
 )
 
 type NoTLSConnErr string
@@ -33,10 +34,24 @@ func Connect(domain, cipherscanbinPath string) ([]byte, error) {
 	var stderr bytes.Buffer
 	comm.Stdout = &out
 	comm.Stderr = &stderr
-	err := comm.Run()
+	err := comm.Start()
 	if err != nil {
 		log.Println(err)
 		return nil, err
+	}
+	waiter := make(chan error, 1)
+	go func() {
+		waiter <- comm.Wait()
+	}()
+	select {
+	case <-time.After(3 * time.Minute):
+		err = fmt.Errorf("cipherscan timed out after 3 minutes on target %s %s", domain, ip)
+		return nil, err
+	case err := <-waiter:
+		if err != nil {
+			log.Println(err)
+			return nil, err
+		}
 	}
 
 	info := CipherscanOutput{}

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -78,6 +78,7 @@ CREATE TABLE scans(
     is_valid         bool NOT NULL,
     completion_perc  integer NOT NULL,
     validation_error varchar NOT NULL,
+    scan_error       varchar NOT NULL,
     conn_info        jsonb NOT NULL,
     ack              bool NOT NULL,
     attempts         integer NULL,

--- a/tlsobs-scanner/main.go
+++ b/tlsobs-scanner/main.go
@@ -205,11 +205,13 @@ func (s scanner) scan(scanID int64, cipherscan string) {
 	// Cipherscan the target
 	js, err := connection.Connect(scan.Target, cipherscan)
 	if err != nil {
-		err, ok := err.(connection.NoTLSConnErr)
+		_, ok := err.(connection.NoTLSConnErr)
 		if ok {
 			//does not implement TLS
 			db.Exec("UPDATE scans SET has_tls=FALSE, completion_perc=100 WHERE id=$1", scanID)
 		} else {
+			//does not implement TLS
+			db.Exec("UPDATE scans SET scan_error=$1, completion_perc=100 WHERE id=$2", err.Error(), scanID)
 			log.WithFields(logrus.Fields{
 				"scan_id": scanID,
 				"error":   err.Error(),

--- a/tlsobs-scanner/main.go
+++ b/tlsobs-scanner/main.go
@@ -210,7 +210,7 @@ func (s scanner) scan(scanID int64, cipherscan string) {
 			//does not implement TLS
 			db.Exec("UPDATE scans SET has_tls=FALSE, completion_perc=100 WHERE id=$1", scanID)
 		} else {
-			//does not implement TLS
+			//appears to implement TLS but cipherscan failed so store an error
 			db.Exec("UPDATE scans SET scan_error=$1, completion_perc=100 WHERE id=$2", err.Error(), scanID)
 			log.WithFields(logrus.Fields{
 				"scan_id": scanID,

--- a/tlsobs/main.go
+++ b/tlsobs/main.go
@@ -118,6 +118,10 @@ getresults:
 		if err != nil {
 			panic(err)
 		}
+		if results.Complperc == 100 && results.ScanError != "" {
+			fmt.Printf("Scan failed with error: %s\n", results.ScanError)
+			os.Exit(81)
+		}
 		if results.Complperc == 100 && !has_cert {
 			// completion is already 100% and we have not yet retrieved the cert,
 			// that means the results were cached. Display a message saying so.


### PR DESCRIPTION
Trying to prevent scans from hanging forever, which slows down scanners. I also added some code to expose the timeout information in the cmdline tool through the API.