### PR TITLE
Add a dockerfile for non-linux local builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ endif
 GO 			:= GOOS=$(OS) GOARCH=$(ARCH) go
 GOGETTER	:= GOPATH=$(shell pwd)/.tmpdeps go get -d
 GOLDFLAGS	:= -ldflags "-X main.version=$(BUILDREV)"
+PWD := $(shell pwd)
 
 all: test tlsobs-scanner tlsobs-api tlsobs tlsobs-runner
 
@@ -64,4 +65,8 @@ ciscotop1m:
 	rm top-1m.csv.zip
 	dos2unix conf/top-1m.csv
 
-.PHONY: all test clean tlsobs-scanner tlsobs-api tlsobs-runner tlsobs vendor truststores cipherscan
+docker:
+	docker build -t tls-observatory:latest -f ./tools/Dockerfile-build .
+	docker run -it -v $(PWD):/go/src/github.com/mozilla/tls-observatory tls-observatory:latest
+
+.PHONY: all test clean tlsobs-scanner tlsobs-api tlsobs-runner tlsobs vendor truststores cipherscan docker

--- a/tools/Dockerfile-build
+++ b/tools/Dockerfile-build
@@ -1,0 +1,6 @@
+FROM golang:1.9
+
+VOLUME /go/src/github.com/mozilla/tls-observatory
+WORKDIR /go/src/github.com/mozilla/tls-observatory
+
+CMD ["make"]


### PR DESCRIPTION
I'm on a mac, so `make` just blew up for me. This essentially just wraps `make` for non-linux hosts.

<details>
<summary>output</summary>

```
adam@~/code/src/github.com/mozilla/tls-observatory$ make docker
docker build -t tls-observatory:latest -f ./tools/Dockerfile-build .
Sending build context to Docker daemon  387.4MB
Step 1/4 : FROM golang:1.9
 ---> 8ebf49f75a15
Step 2/4 : VOLUME /go/src/github.com/mozilla/tls-observatory
 ---> Running in 3ef2c591083f
Removing intermediate container 3ef2c591083f
 ---> 38b67db5820c
Step 3/4 : WORKDIR /go/src/github.com/mozilla/tls-observatory
Removing intermediate container 58ee8646e7ec
 ---> aab4887ba11a
Step 4/4 : CMD ["make"]
 ---> Running in 4cc9dc076533
Removing intermediate container 4cc9dc076533
 ---> 5c2fcd34892f
Successfully built 5c2fcd34892f
Successfully tagged tls-observatory:latest
docker run -it -v /Users/adam/code/src/github.com/mozilla/tls-observatory:/go/src/github.com/mozilla/tls-observatory tls-observatory:latest
GOOS=linux GOARCH=amd64 go test github.com/mozilla/tls-observatory/worker/mozillaEvaluationWorker/
ok  	github.com/mozilla/tls-observatory/worker/mozillaEvaluationWorker	0.009s
GOOS=linux GOARCH=amd64 go test github.com/mozilla/tls-observatory/tlsobs-runner
ok  	github.com/mozilla/tls-observatory/tlsobs-runner	0.008s
echo building TLS Observatory Scanner for linux/amd64
building TLS Observatory Scanner for linux/amd64
GOOS=linux GOARCH=amd64 go build  -o /go/bin/tlsobs-scanner"" -ldflags "-X main.version=20180304+a64118f7.dev" github.com/mozilla/tls-observatory/tlsobs-scanner
echo building tlsobs-api for linux/amd64
building tlsobs-api for linux/amd64
GOOS=linux GOARCH=amd64 go build  -o /go/bin/tlsobs-api"" -ldflags "-X main.version=20180304+a64118f7.dev" github.com/mozilla/tls-observatory/tlsobs-api
echo building tlsobs client for linux/amd64
building tlsobs client for linux/amd64
GOOS=linux GOARCH=amd64 go build  -o /go/bin/tlsobs"" -ldflags "-X main.version=20180304+a64118f7.dev" github.com/mozilla/tls-observatory/tlsobs
echo building tlsobs-runner for linux/amd64
building tlsobs-runner for linux/amd64
GOOS=linux GOARCH=amd64 go build  -o /go/bin/tlsobs-runner"" -ldflags "-X main.version=20180304+a64118f7.dev" github.com/mozilla/tls-observatory/tlsobs-runner
```

</details>