### PR TITLE
connection: Print stderr from running cipherscan

### DIFF
--- a/connection/retriever.go
+++ b/connection/retriever.go
@@ -36,6 +36,7 @@ func Connect(domain, cipherscanbinPath string) ([]byte, error) {
 	comm.Stderr = &stderr
 	err := comm.Start()
 	if err != nil {
+		log.Println(stderr.String())
 		log.Println(err)
 		return nil, err
 	}


### PR DESCRIPTION
I had an old version of bash, but didn't find out until running `cipherscan` manually. 