### PR TITLE
tlsobs: Trim trailing slash from target

### DIFF
--- a/tlsobs/main.go
+++ b/tlsobs/main.go
@@ -76,6 +76,7 @@ func main() {
 	// also trim http:// prefix ( in case someone has a really wrong idea of what
 	// the observatory does...)
 	target = strings.TrimPrefix(target, "http://")
+	target = strings.TrimSuffix(target, "/") // trailing slash
 
 	if *rescan {
 		rescanP = "&rescan=true"


### PR DESCRIPTION
Running something like this failed, which surprised me for a bit. 

```
$ ~/code/bin/tlsobs -observatory http://localhost:8083 -r https://revoked.badssl.com/ 
Scanning https://revoked.badssl.com/ (id 8)
Retrieving cached results from 1.010450033s ago. To run a new scan, use '-r'.

revoked.badssl.com/ does not support SSL/TLS
```