### PR TITLE
Stop monitoring everything.me

### DIFF
--- a/conf/runner.yaml
+++ b/conf/runner.yaml
@@ -63,8 +63,6 @@ runs:
         - symbols.mozilla.org
 
         # everything.me
-        - api.everything.me
-        - appsearch.services.mozilla.com
         - geodude.services.mozilla.com
 
         # Firefox Accounts
@@ -423,8 +421,6 @@ runs:
 
     # everything.me paging
     - targets:
-        - api.everything.me
-        - appsearch.services.mozilla.com
         - geodude.services.mozilla.com
       assertions:
         - certificate:


### PR DESCRIPTION
The service is decommissioned per
* https://bugzilla.mozilla.org/show_bug.cgi?id=1432964
* https://bugzilla.mozilla.org/show_bug.cgi?id=1447049