### PR TITLE
Switch off constraintscrypto, require Go 1.10 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: /go/src/github.com/mozilla/tls-observatory
     docker:
-      - image: circleci/golang:1.9
+      - image: circleci/golang:1.10
       - image: circleci/postgres:9.6-alpine
         environment:
           POSTGRES_USER: postgres

--- a/README.md
+++ b/README.md
@@ -39,10 +39,10 @@ Want the WebUI? Check out [Mozilla's Observatory](https://observatory.mozilla.or
 ## Getting started
 
 You can use the TLS Observatory to compare your site against the mozilla guidelines.
-It requires Golang 1.7+ to be installed:
+It requires Golang 1.10+ to be installed:
 ```bash
 $ go version
-go version go1.7 linux/amd64
+go version go1.10 linux/amd64
 
 $ export GOPATH="$HOME/go"
 $ mkdir $GOPATH
@@ -124,8 +124,8 @@ root@05676e6789dd:/go/src/github.com/mozilla/tls-observatory# make
 However, even with the docker container, you will need to setup your own
 postgresql database. See below.
 
-To build a development environment from scratch, you will need Go 1.7 or above.
-You can set it up on your own machine or via the `golang:1.7` Docker
+To build a development environment from scratch, you will need Go 1.10 or above.
+You can set it up on your own machine or via the `golang:1.10` Docker
 container.
 
 Retrieve a copy of the source code using `go get`, to place it directly
@@ -133,7 +133,7 @@ under `$GOPATH/src/github.com/mozilla/tls-observatory`, then use `make`
 to build all components.
 
 ```bash
-$ docker run -it golang:1.7
+$ docker run -it golang:1.10
 
 root@c63f11b8852b:/go# go get github.com/mozilla/tls-observatory
 package github.com/mozilla/tls-observatory: no buildable Go source files in /go/src/github.com/mozilla/tls-observatory

--- a/certificate/certificate.go
+++ b/certificate/certificate.go
@@ -363,15 +363,15 @@ func getCertExtensions(cert *x509.Certificate) Extensions {
 	crld := make([]string, 0)
 	crld = append(crld, cert.CRLDistributionPoints...)
 	constraints, _ := certconstraints.Get(cert)
-	ipNetSliceToStringSlice := func(in []net.IPNet) []string {
+	ipNetSliceToStringSlice := func(in []*net.IPNet) []string {
 		out := make([]string, 0)
 		for _, ipnet := range in {
 			out = append(out, ipnet.String())
 		}
 		return out
 	}
-	permittedIPAddresses := ipNetSliceToStringSlice(constraints.PermittedIPAddresses)
-	excludedIPAddresses := ipNetSliceToStringSlice(constraints.ExcludedIPAddresses)
+	permittedIPAddresses := ipNetSliceToStringSlice(constraints.PermittedIPRanges)
+	excludedIPAddresses := ipNetSliceToStringSlice(constraints.ExcludedIPRanges)
 	ext := Extensions{
 		AuthorityKeyId:           base64.StdEncoding.EncodeToString(cert.AuthorityKeyId),
 		SubjectKeyId:             base64.StdEncoding.EncodeToString(cert.SubjectKeyId),

--- a/certificate/constraints/constraints.go
+++ b/certificate/constraints/constraints.go
@@ -1,7 +1,7 @@
 package certconstraints
 
 import (
-	constraintsx509 "constraintcrypto/x509"
+	// constraintsx509 "constraintcrypto/x509"
 	"crypto/x509"
 	"fmt"
 	"net"
@@ -9,16 +9,15 @@ import (
 )
 
 type Constraints struct {
-	PermittedDNSDomains  []string
-	ExcludedDNSDomains   []string
-	PermittedIPAddresses []net.IPNet
-	ExcludedIPAddresses  []net.IPNet
+	PermittedDNSDomains []string
+	ExcludedDNSDomains  []string
+	PermittedIPRanges   []*net.IPNet
+	ExcludedIPRanges    []*net.IPNet
 }
-
 
 // Get returns the Constraints for a given x509 certificate
 func Get(cert *x509.Certificate) (*Constraints, error) {
-	certs, err := constraintsx509.ParseCertificates(cert.Raw)
+	certs, err := x509.ParseCertificates(cert.Raw)
 	if err != nil {
 		return nil, err
 	}
@@ -29,9 +28,9 @@ func Get(cert *x509.Certificate) (*Constraints, error) {
 
 	return &Constraints{
 		PermittedDNSDomains: constraintCert.PermittedDNSDomains,
-		ExcludedDNSDomains: constraintCert.ExcludedDNSDomains,
-		PermittedIPAddresses: constraintCert.PermittedIPAddresses,
-		ExcludedIPAddresses: constraintCert.ExcludedIPAddresses,
+		ExcludedDNSDomains:  constraintCert.ExcludedDNSDomains,
+		PermittedIPRanges:   constraintCert.PermittedIPRanges,
+		ExcludedIPRanges:    constraintCert.ExcludedIPRanges,
 	}, nil
 }
 
@@ -39,7 +38,7 @@ func isAllZeros(buf []byte, length int) bool {
 	if length > len(buf) {
 		return false
 	}
-	for i:=0; i<length; i++ {
+	for i := 0; i < length; i++ {
 		if buf[i] != 0 {
 			return false
 		}
@@ -87,7 +86,7 @@ func IsTechnicallyConstrained(cert *x509.Certificate) bool {
 	var excludesIPv4 bool
 	var excludesIPv6 bool
 	constraints, _ := Get(cert)
-	for _, cidr := range constraints.ExcludedIPAddresses {
+	for _, cidr := range constraints.ExcludedIPRanges {
 		if cidr.IP.Equal(net.IPv4zero) && isAllZeros(cidr.Mask, net.IPv4len) {
 			excludesIPv4 = true
 		}
@@ -96,7 +95,7 @@ func IsTechnicallyConstrained(cert *x509.Certificate) bool {
 		}
 	}
 
-	hasIPAddressInPermittedSubtrees := len(constraints.PermittedIPAddresses) > 0
+	hasIPAddressInPermittedSubtrees := len(constraints.PermittedIPRanges) > 0
 	hasIPAddressesInExcludedSubtrees := excludesIPv4 && excludesIPv6
 
 	// There must be at least one DNSname constraint


### PR DESCRIPTION
Part of the change from https://github.com/mozilla/tls-observatory/pull/322, but without the deletion of that vendor folder.

**This change requires Go 1.10+ now**, because of the additional fields on `certificate.Certificate`. 