### PR TITLE
Fix creation of EKU OID column

### DIFF
--- a/database/migrations/1.3.3.sql
+++ b/database/migrations/1.3.3.sql
@@ -1,1 +1,2 @@
 ALTER TABLE certificates ADD COLUMN x509_extendedKeyUsageOID jsonb NULL;
+UPDATE certificates SET x509_extendedkeyusageoid = '[]'::jsonb WHERE x509_extendedkeyusageoid IS NULL;

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -19,6 +19,7 @@ CREATE TABLE certificates(
     x509_basicConstraints       varchar NULL,
     x509_crlDistributionPoints  jsonb NULL,
     x509_extendedKeyUsage       jsonb NULL,
+    x509_extendedKeyUsageOID    jsonb NULL,
     x509_authorityKeyIdentifier varchar NULL,
     x509_subjectKeyIdentifier   varchar NULL,
     x509_keyUsage               jsonb NULL,
@@ -141,4 +142,3 @@ GRANT INSERT ON analysis, certificates, scans, trust TO tlsobsscanner;
 GRANT UPDATE ON analysis, certificates, scans, trust TO tlsobsscanner;
 GRANT USAGE ON analysis_id_seq, certificates_id_seq, scans_id_seq, trust_id_seq TO tlsobsscanner;
 
-ALTER TABLE certificates ADD COLUMN x509_extendedKeyUsageOID jsonb NULL;


### PR DESCRIPTION
When adding new columns, existing certs must be updated to prevent the parsing to fail.