### PR TITLE
certsplainer: insert colons in cert serial

### DIFF
--- a/static/certsplainer.js
+++ b/static/certsplainer.js
@@ -178,7 +178,7 @@ function setFieldsFromJSON(properties) {
         return;
     }
     setField('version', properties.version);
-    setField('serialNumber', properties.serialNumber.toLowerCase());
+    setField('serialNumber', insertColons(properties.serialNumber.toLowerCase()));
     setField('issuer', formatHTMLCommonName(properties.issuer, properties.issuer.id));
     setField('notBefore', properties.validity.notBefore);
     setField('notAfter', properties.validity.notAfter);
@@ -441,4 +441,16 @@ function send(e) {
             logs.textContent = 'Error: ' + err;
             logs.style.color = 'Red';
         });
+}
+
+function insertColons(str) {
+    var ret = [];
+    var i;
+    var len;
+
+    for(i = 0, len = str.length; i < len; i += 2) {
+       ret.push(str.substr(i, 2));
+    }
+
+    return ret.join(':');
 }


### PR DESCRIPTION
Simple representation change that applies only to certsplainer, not the api.

## Checklist
* [N/A] Run `make`, `gofmt` and `golint` your code, and run a test scan on your local machine before submitting for review.
* [N/A] Workers needs an AnalysisPrinter, registered via `worker.RegisterPrinter()` (which is separate from `worker.RegisterWorker()`), and imported in [tlsobs](https://github.com/mozilla/tls-observatory/blob/master/tlsobs/main.go#L20-L28) ([example](https://github.com/mozilla/tls-observatory/blob/master/worker/awsCertlint/awsCertlint.go#L39-L56)).
* [N/A] When adding new columns to the database, also add a DB migration script under `database/migrations` named the **next** release (eg. if current release is 1.3.2, migration file will be `1.3.3.sql`).
* [N/A] When new columns require data to be recomputed, add a script under `/tools` ([example](https://github.com/mozilla/tls-observatory/blob/master/tools/fixSHA256SubjectSPKI.go)) that updates the database and will be run by administrators.
