### PR TITLE
Re-add support for Subject SPKI hash

### DIFF
--- a/certificate/certificate.go
+++ b/certificate/certificate.go
@@ -61,11 +61,12 @@ type MozillaPolicy struct {
 }
 
 type Hashes struct {
-	MD5        string `json:"md5,omitempty"`
-	SHA1       string `json:"sha1,omitempty"`
-	SHA256     string `json:"sha256,omitempty"`
-	SPKISHA256 string `json:"spki-sha256,omitempty"`
-	PKPSHA256  string `json:"pin-sha256,omitempty"`
+	MD5               string `json:"md5,omitempty"`
+	SHA1              string `json:"sha1,omitempty"`
+	SHA256            string `json:"sha256,omitempty"`
+	SPKISHA256        string `json:"spki-sha256,omitempty"`
+	SubjectSPKISHA256 string `json:"subject-spki-sha256,omitempty"`
+	PKPSHA256         string `json:"pin-sha256,omitempty"`
 }
 
 type Validity struct {
@@ -209,6 +210,13 @@ var PublicKeyAlgorithm = [...]string{
 	"RSA",
 	"DSA",
 	"ECDSA",
+}
+
+func SubjectSPKISHA256(cert *x509.Certificate) string {
+	h := sha256.New()
+	h.Write(cert.RawSubject)
+	h.Write(cert.RawSubjectPublicKeyInfo)
+	return fmt.Sprintf("%X", h.Sum(nil))
 }
 
 func SPKISHA256(cert *x509.Certificate) string {
@@ -572,6 +580,7 @@ func CertToStored(cert *x509.Certificate, parentSignature, domain, ip string, TS
 	stored.Hashes.SHA1 = SHA1Hash(cert.Raw)
 	stored.Hashes.SHA256 = SHA256Hash(cert.Raw)
 	stored.Hashes.SPKISHA256 = SPKISHA256(cert)
+	stored.Hashes.SubjectSPKISHA256 = SubjectSPKISHA256(cert)
 	stored.Hashes.PKPSHA256 = PKPSHA256Hash(cert)
 
 	stored.Raw = base64.StdEncoding.EncodeToString(cert.Raw)

--- a/database/migrations/1.3.5.sql
+++ b/database/migrations/1.3.5.sql
@@ -1,0 +1,2 @@
+ALTER TABLE certificates RENAME COLUMN sha256_subject_spki TO sha256_spki;
+ALTER TABLE certificates ADD COLUMN sha256_subject_spki varchar;

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -2,6 +2,7 @@ CREATE TABLE certificates(
     id                          serial primary key,
     sha1_fingerprint            varchar NOT NULL,
     sha256_fingerprint          varchar NOT NULL,
+    sha256_spki                 varchar NOT NULL,
     sha256_subject_spki         varchar NOT NULL,
     pkp_sha256                  varchar NOT NULL,
     serial_number               varchar NULL,

--- a/static/certsplainer.html
+++ b/static/certsplainer.html
@@ -34,6 +34,7 @@
             <tr><td>sha1 hash</td><td id="sha1hash"></td></tr>
             <tr><td>sha256 hash</td><td id="sha256hash"></td></tr>
             <tr><td>spki sha256</td><td id="spki-sha256"></td></tr>
+            <tr><td>subject spki sha256</td><td id="subject-spki-sha256"></td></tr>
             <tr><td>hpkp pin-sha256</td><td id="pin-sha256"></td></tr>
             <tr><td>tls observatory id</td><td id="id"></td></tr>
         </table>

--- a/static/certsplainer.js
+++ b/static/certsplainer.js
@@ -113,8 +113,8 @@ function setField(field, value) {
 function clearFields() {
     for (let id of ['version', 'serialNumber', 'issuer', 'notBefore', 'notAfter',
         'subject', 'signatureAlgorithm', 'keySize', 'exponent', 'curve',
-        'sha1hash', 'sha256hash', 'spki-sha256', 'pin-sha256', 'id',
-        'permalink', 'help'
+        'sha1hash', 'sha256hash', 'spki-sha256', 'subject-spki-sha256', 'pin-sha256',
+        'id', 'permalink', 'help'
     ]) {
         setField(id, '');
     }
@@ -196,6 +196,7 @@ function setFieldsFromJSON(properties) {
     setField('sha1hash', properties.hashes.sha1.toUpperCase());
     setField('sha256hash', properties.hashes.sha256.toUpperCase());
     setField('spki-sha256', properties.hashes['spki-sha256'].toUpperCase());
+    setField('subject-spki-sha256', properties.hashes['subject-spki-sha256'].toUpperCase());
     setField('pin-sha256', properties.hashes['pin-sha256'].toUpperCase());
     setField('id', permanentLink(properties.id, properties.id));
     setField('certificate', "-----BEGIN CERTIFICATE-----\n" + properties.Raw.replace(/(\S{64}(?!$))/g, "$1\n") + "\n-----END CERTIFICATE-----" );

--- a/tools/fixSHA256SubjectSPKI.go
+++ b/tools/fixSHA256SubjectSPKI.go
@@ -66,7 +66,7 @@ func main() {
 				fmt.Println("error while x509 parsing cert", id, ":", err)
 				continue
 			}
-			updates[id] = certificate.SPKISHA256(c)
+			updates[id] = certificate.SubjectSPKISHA256(c)
 		}
 		if i == 0 {
 			fmt.Println("done!")


### PR DESCRIPTION
In 1.2.37, I removed support for Subject SPKI (#144) and turned the value into standard SPKI. Turns out this was a mistake, and Subject SPKI is very much needed by CCADB. This patch re-adds it into a new column.

## Checklist
* [x] Run `make`, `gofmt` and `golint` your code, and run a test scan on your local machine before submitting for review.
* [x] Workers needs an AnalysisPrinter, registered via `worker.RegisterPrinter()` (which is separate from `worker.RegisterWorker()`), and imported in [tlsobs](https://github.com/mozilla/tls-observatory/blob/master/tlsobs/main.go#L20-L28) ([example](https://github.com/mozilla/tls-observatory/blob/master/worker/awsCertlint/awsCertlint.go#L39-L56)).
* [x] When adding new columns to the database, also add a DB migration script under `database/migrations` named the **next** release (eg. if current release is 1.3.2, migration file will be `1.3.3.sql`).
* [x] When new columns require data to be recomputed, add a script under `/tools` ([example](https://github.com/mozilla/tls-observatory/blob/master/tools/fixSHA256SubjectSPKI.go)) that updates the database and will be run by administrators.
