### PR TITLE
Taskcluster: New domains

### DIFF
--- a/conf/runner.yaml
+++ b/conf/runner.yaml
@@ -225,6 +225,11 @@ runs:
         - eolinator.services.mozilla.com
         - sync-4-us-east-1.stage.mozaws.net
 
+        # Taskcluster
+        - firefox-ci-tc.services.mozilla.com
+        - community-tc.services.mozilla.com
+        - stage.taskcluster.nonprod.cloudops.mozgcp.net
+
         # Tiles
         - activity-stream-icons.services.mozilla.com
         - tiles.cdn.mozilla.net
@@ -877,35 +882,19 @@ runs:
               recipients:
                   - hostmaster+tlsobs@mozilla.com
 
-    # TaskCluster stuff
+    # Taskcluster paging
     - targets:
-        - auth.taskcluster.net
-        - aws-provisioner.taskcluster.net
-        - events.taskcluster.net
-        - hooks.taskcluster.net
-        - index.taskcluster.net
-        - purge-cache.taskcluster.net
-        - queue.taskcluster.net
-        - scheduler.taskcluster.net
-        - secrets.taskcluster.net
-        - taskcluster-github.herokuapp.com
-        - github.taskcluster.net
-        - tools.taskcluster.net
-        - docs.taskcluster.net
-        - login.taskcluster.net
-        - cors-proxy.taskcluster.net
+        - firefox-ci-tc.services.mozilla.com
+        - community-tc.services.mozilla.com
       assertions:
         - certificate:
             validity:
                 notafter: ">14d"
-        - analysis:
-            analyzer: mozillaEvaluationWorker
-            result: '{"level": "intermediate"}'
-      cron: "0 0 * * *"
+      cron: "30 18 * * *"
       notifications:
           email:
               recipients:
-                - b64:dGFza2NsdXN0ZXItbm90aWZpY2F0aW9ucyt0bHNvYnNAbW96aWxsYS5jb20=
+                  - b64:dGFza2NsdXN0ZXItZmlyZWZveGNpQG1vei1zdmMtb3BzLnBhZ2VyZHV0eS5jb20K
 
 smtp:
     host: gator1

--- a/conf/runner.yaml
+++ b/conf/runner.yaml
@@ -229,6 +229,9 @@ runs:
         - firefox-ci-tc.services.mozilla.com
         - community-tc.services.mozilla.com
         - stage.taskcluster.nonprod.cloudops.mozgcp.net
+        - firefoxci-websocktunnel.services.mozilla.com
+        - community-websocktunnel.services.mozilla.com
+        - websocktunnel-stage.taskcluster.nonprod.cloudops.mozgcp.net
 
         # Tiles
         - activity-stream-icons.services.mozilla.com
@@ -886,6 +889,8 @@ runs:
     - targets:
         - firefox-ci-tc.services.mozilla.com
         - community-tc.services.mozilla.com
+        - firefoxci-websocktunnel.services.mozilla.com
+        - community-websocktunnel.services.mozilla.com
       assertions:
         - certificate:
             validity:


### PR DESCRIPTION
THis configures the general monitoring that will email us after 35 days, and will also page us for the two prod deployments if unaddressed with 14 days remaining.

cc @edunham