### PR TITLE
bump golang version to 1.15

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: /go/src/github.com/mozilla/tls-observatory
     docker:
-      - image: golang:1.13
+      - image: golang:1.15
       - image: circleci/postgres:11-alpine
         environment:
           POSTGRES_USER: postgres

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 # This is based on the original Golang Dockerfile for Debian Stretch
 # https://github.com/docker-library/golang/blob/906e04de73168f643c5c2b40dca0877a14d2377c/1.10/stretch/Dockerfile
 
-FROM golang:1.13
+FROM golang:1.15
 MAINTAINER secops+tlsobs@mozilla.com
 
 ENV GOPATH /go

--- a/README.md
+++ b/README.md
@@ -42,10 +42,10 @@ Want the WebUI? Check out [Mozilla's Observatory](https://observatory.mozilla.or
 ## Getting started
 
 You can use the TLS Observatory to compare your site against the mozilla guidelines.
-It requires Golang 1.10+ to be installed:
+It requires Golang 1.15+ to be installed:
 ```bash
 $ go version
-go version go1.10 linux/amd64
+go version go1.15 linux/amd64
 
 $ export GOPATH="$HOME/go"
 $ mkdir $GOPATH
@@ -127,8 +127,8 @@ root@05676e6789dd:/go/src/github.com/mozilla/tls-observatory# make
 However, even with the docker container, you will need to setup your own
 postgresql database. See below.
 
-To build a development environment from scratch, you will need Go 1.10 or above.
-You can set it up on your own machine or via the `golang:1.10` Docker
+To build a development environment from scratch, you will need Go 1.15 or above.
+You can set it up on your own machine or via the `golang:1.15` Docker
 container.
 
 Retrieve a copy of the source code using `go get`, to place it directly
@@ -136,7 +136,7 @@ under `$GOPATH/src/github.com/mozilla/tls-observatory`, then use `make`
 to build all components.
 
 ```bash
-$ docker run -it golang:1.10
+$ docker run -it golang:1.15
 
 root@c63f11b8852b:/go# go get github.com/mozilla/tls-observatory
 package github.com/mozilla/tls-observatory: no buildable Go source files in /go/src/github.com/mozilla/tls-observatory


### PR DESCRIPTION
Update CI and docker image to a supported golang version

## Checklist
* [ ] Run `make`, `gofmt` and `golint` your code, and run a test scan on your local machine before submitting for review.
* [ ] Workers needs an AnalysisPrinter, registered via `worker.RegisterPrinter()` (which is separate from `worker.RegisterWorker()`), and imported in [tlsobs](https://github.com/mozilla/tls-observatory/blob/master/tlsobs/main.go#L20-L28) ([example](https://github.com/mozilla/tls-observatory/blob/master/worker/awsCertlint/awsCertlint.go#L39-L56)).
* [ ] When adding new columns to the database, also add a DB migration script under `database/migrations` named the **next** release (eg. if current release is 1.3.2, migration file will be `1.3.3.sql`).
* [ ] When new columns require data to be recomputed, add a script under `/tools` ([example](https://github.com/mozilla/tls-observatory/blob/master/tools/fixSHA256SubjectSPKI.go)) that updates the database and will be run by administrators.
