### PR TITLE
scanner: batch cert last_seen updates to reduce DB lock contention

### DIFF
--- a/database/certificate.go
+++ b/database/certificate.go
@@ -355,7 +355,6 @@ func (db *DB) UpdateCertificateRank(id, rank int64) error {
 // UpdateCertLastSeen updates the last_seen timestamp of the input certificate.
 // Outputs an error if it occurs.
 func (db *DB) UpdateCertLastSeen(cert *certificate.Certificate) error {
-
 	_, err := db.Exec("UPDATE certificates SET last_seen=$1 WHERE sha1_fingerprint=$2", cert.LastSeenTimestamp, cert.Hashes.SHA1)
 	return err
 }
@@ -364,6 +363,13 @@ func (db *DB) UpdateCertLastSeen(cert *certificate.Certificate) error {
 // Outputs an error if it occurs.
 func (db *DB) UpdateCertLastSeenByID(id int64) error {
 	_, err := db.Exec("UPDATE certificates SET last_seen=$1 WHERE id=$2", time.Now(), id)
+	return err
+}
+
+// UpdateCertsLastSeenByID updates the last_seen timestamp for certificates with the given id.
+// Outputs an error if it occurs.
+func (db *DB) UpdateCertsLastSeenByID(ids []int64) error {
+	_, err := db.Exec("UPDATE certificates SET last_seen=$1 WHERE id = ANY($2)", time.Now(), pq.Array(ids))
 	return err
 }
 

--- a/database/certificate.go
+++ b/database/certificate.go
@@ -359,7 +359,7 @@ func (db *DB) UpdateCertLastSeen(cert *certificate.Certificate) error {
 	return err
 }
 
-// UpdateCertLastSeenWithID updates the last_seen timestamp of the certificate with the given id.
+// UpdateCertLastSeenByID updates the last_seen timestamp of the certificate with the given id.
 // Outputs an error if it occurs.
 func (db *DB) UpdateCertLastSeenByID(id int64) error {
 	_, err := db.Exec("UPDATE certificates SET last_seen=$1 WHERE id=$2", time.Now(), id)


### PR DESCRIPTION
batch cert `last_seen` updates to reduce DB lock contention

refs: https://gist.github.com/g-k/7d2e8835399018a51a0407fb4337d75a and prior poking with @Micheletto 

## Checklist

* [x] Run `make`, `gofmt` and `golint` your code, and run a test scan on your local machine before submitting for review.

- [x] `make`
- [x] `gofmt -d database/certificate.go tlsobs-scanner/analyser.go`
- [x] `golint`

NB: `gofmt` and `golint` have a pile of changes and warnings

- [x] confirm that inserting code does not depend on last seen timestamps being updated as the scan certmap is analysed; as far as I can tell the `last_seen` column is just used for statistics (e.g. certs and new certs seen in the past 24h)  
- [x] `db.GetCertIDBySHA256Fingerprint` just uses the `sha256_fingerprint` column
- [x] db.InsertTrustToDB` , `db.GetCurrentTrustID` and `db.UpdateTrust` just use the `is_current` column in the `trust` table 
- [x] `db.InsertCertificate` adds a row to the `certificates` table without looking at existing `last_seen` values

I haven't run perf tests, but should be able to verify the changes in stage.

r? @ajvb 