### PR TITLE
Remove monitring for elmo

### DIFF
--- a/conf/runner.yaml
+++ b/conf/runner.yaml
@@ -71,10 +71,6 @@ runs:
         # Detectportal
         - detectportal.firefox.com
 
-        # elmo
-        - l10n.mozilla.org
-        - l10n.allizom.org
-
         # Firefox Accounts
         - accounts.firefox.com
         - api.accounts.firefox.com
@@ -454,20 +450,6 @@ runs:
           email:
               recipients:
                   - b64:c29jb3Jyb0Btb3otc3ZjLW9wcy5wYWdlcmR1dHkuY29t
-
-    #  Elmo paging
-    - targets:
-        - l10n.mozilla.org
-        - l10n.allizom.org
-      assertions:
-        - certificate:
-            validity:
-                notafter: ">14d"
-      cron: "30 18 * * *"
-      notifications:
-          email:
-              recipients:
-                  - b64ZWxtb0Btb3otc3ZjLW9wcy5wYWdlcmR1dHkuY29tCg==
 
     # everything.me paging
     - targets:


### PR DESCRIPTION
l10n.mozilla.org was decommed a while back. This is now a redirect that
lives in refractr. It is monitored by Web SRE and should not page
anyone.


