### PR TITLE
Refactor tlsobs main routine.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,14 @@ $ mkdir $GOPATH
 $ export PATH=$GOPATH/bin:$PATH
 ```
 
+Also required is bash >=v4.
+```bash
+$ /usr/bin/env bash
+$ echo ${BASH_VERSINFO[0]}
+4
+```
+Version 4 or more is ok.
+
 Then get the binary:
 
 ```bash

--- a/tlsobs/scan_test.go
+++ b/tlsobs/scan_test.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestScanTooManyRequests(t *testing.T) {
+	t.Parallel()
+	server := testServer(http.StatusTooManyRequests, "try later")
+	defer server.Close()
+	_, err := postScan(mustURL(server.URL))
+	if err.Error() != fmt.Sprintf("scan failed with error code 429: try later") {
+		t.Fatalf("server responded with too many requests and client did not handle it")
+	}
+}
+
+func TestScanOK(t *testing.T) {
+	t.Parallel()
+	server := testServer(http.StatusOK, "{\"scan_id\": 3}")
+	defer server.Close()
+	scanID, err := postScan(mustURL(server.URL))
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if scanID != 3 {
+		t.Fatalf("unexpected scan id: %d [expected 3]", scanID)
+	}
+}
+
+func testServer(statusCode int, body string) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(statusCode)
+		_, _ = w.Write([]byte(body))
+	}))
+}

--- a/tlsobs/url_test.go
+++ b/tlsobs/url_test.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestBuildScanURL(t *testing.T) {
+	t.Parallel()
+	//goland:noinspection HttpUrlsUsage
+	testCases := []struct {
+		targetURL   string
+		rescan      bool
+		expectedURL string
+	}{
+		{"target.com", false, "https://observatory.com/api/v1/scan?target=target.com"},
+		{"http://target.com", false, "https://observatory.com/api/v1/scan?target=target.com"},
+		{"https://target.com", false, "https://observatory.com/api/v1/scan?target=target.com"},
+		{"https://target.com", true, "https://observatory.com/api/v1/scan?target=target.com&rescan=true"},
+		{"https://target.com/", true, "https://observatory.com/api/v1/scan?target=target.com&rescan=true"},
+	}
+
+	for _, tc := range testCases {
+		name := fmt.Sprintf("target=%s rescan=%t", tc.targetURL, tc.rescan)
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			u := buildScanURL("https://observatory.com", tc.targetURL, tc.rescan)
+			if u != tc.expectedURL {
+				t.Fatalf("expected '%s' == '%s'", u, tc.expectedURL)
+			}
+		})
+	}
+}
+
+func TestMustURL(t *testing.T) {
+	t.Parallel()
+	testCases := []string{
+		"https://observatory.com",
+		"observatory.com",
+		"foo",
+	}
+	for _, tc := range testCases {
+		t.Run(tc, func(t *testing.T) {
+			t.Parallel()
+			u := mustURL(tc)
+			if u.String() != tc {
+				t.Fatalf("expected '%s'", tc)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Invoke `postScan` to post to scan endpoint instead of having the code inline.
Added tests for postScan and building url to scan endpoint.


## Checklist
* [x] Run `make`, `gofmt` and `golint` your code, and run a test scan on your local machine before submitting for review.
* [x] Workers needs an AnalysisPrinter, registered via `worker.RegisterPrinter()` (which is separate from `worker.RegisterWorker()`), and imported in [tlsobs](https://github.com/mozilla/tls-observatory/blob/master/tlsobs/main.go#L20-L28) ([example](https://github.com/mozilla/tls-observatory/blob/master/worker/awsCertlint/awsCertlint.go#L39-L56)).
* [x] When adding new columns to the database, also add a DB migration script under `database/migrations` named the **next** release (eg. if current release is 1.3.2, migration file will be `1.3.3.sql`).
* [x] When new columns require data to be recomputed, add a script under `/tools` ([example](https://github.com/mozilla/tls-observatory/blob/master/tools/fixSHA256SubjectSPKI.go)) that updates the database and will be run by administrators.
