### PR TITLE
ppc64le: added support for ppc64le architecture

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,13 +8,17 @@ BUILDENV	:= dev
 BUILDREV	:= $(BUILDDATE)+$(BUILDREF).$(BUILDENV)
 
 # Supported OSes: linux darwin windows
-# Supported ARCHes: 386 amd64
+# Supported ARCHes: 386 amd64 ppc64le
 ifeq ($(OS),windows)
 	OS := windows
 else
 	OS := $(shell uname -s | tr [:upper:] [:lower:])
 endif
+ifeq ($(shell uname -m), ppc64le)
+ARCH := ppc64le
+else
 ARCH := amd64
+endif
 
 ifeq ($(OS),windows)
 	BINSUFFIX   := ".exe"


### PR DESCRIPTION
-Makefile: Added support to build for ppc64le architecture

## Checklist
* [x] Run `make`, `gofmt` and `golint` your code, and run a test scan on your local machine before submitting for review.
* [x] Workers needs an AnalysisPrinter, registered via `worker.RegisterPrinter()` (which is separate from `worker.RegisterWorker()`), and imported in [tlsobs](https://github.com/mozilla/tls-observatory/blob/master/tlsobs/main.go#L20-L28) ([example](https://github.com/mozilla/tls-observatory/blob/master/worker/awsCertlint/awsCertlint.go#L39-L56)).
* [x] When adding new columns to the database, also add a DB migration script under `database/migrations` named the **next** release (eg. if current release is 1.3.2, migration file will be `1.3.3.sql`).
* [x] When new columns require data to be recomputed, add a script under `/tools` ([example](https://github.com/mozilla/tls-observatory/blob/master/tools/fixSHA256SubjectSPKI.go)) that updates the database and will be run by administrators.
