### PR TITLE
Sync the SignatureAlgorithm list with https://pkg.go.dev/crypto/x509#SignatureAlgorithm

### DIFF
--- a/certificate/certificate.go
+++ b/certificate/certificate.go
@@ -169,6 +169,10 @@ var SignatureAlgorithm = [...]string{
 	"ECDSAWithSHA256",
 	"ECDSAWithSHA384",
 	"ECDSAWithSHA512",
+	"SHA256WithRSAPSS",
+	"SHA384WithRSAPSS",
+	"SHA512WithRSAPSS",
+	"PureEd25519",
 }
 
 var ExtKeyUsage = [...]string{


### PR DESCRIPTION
This PR enables `POST /api/v1/certificate` to process RSA-PSS certificates, as requested by #436.